### PR TITLE
feat: domain CRUD + DNS TXT verification (fixes #14)

### DIFF
--- a/web/src/lib/server/doh.test.ts
+++ b/web/src/lib/server/doh.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lookupTxt, unquoteTxt } from './doh';
+
+describe('unquoteTxt', () => {
+	it('joins multiple quoted segments', () => {
+		expect(unquoteTxt('"vigil-verify=abc" "def"')).toBe('vigil-verify=abcdef');
+	});
+	it('unescapes escaped chars', () => {
+		expect(unquoteTxt('"a\\"b"')).toBe('a"b');
+	});
+	it('returns input as-is when no quotes are present', () => {
+		expect(unquoteTxt('plain')).toBe('plain');
+	});
+});
+
+describe('lookupTxt', () => {
+	const realFetch = globalThis.fetch;
+	let calls: string[] = [];
+
+	beforeEach(() => {
+		calls = [];
+	});
+	afterEach(() => {
+		globalThis.fetch = realFetch;
+		vi.restoreAllMocks();
+	});
+
+	const respond = (body: unknown, ok = true, status = 200) =>
+		new Response(JSON.stringify(body), {
+			status: ok ? 200 : status,
+			headers: { 'content-type': 'application/json' }
+		});
+
+	it('uses Cloudflare on first try and returns parsed TXT', async () => {
+		globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+			calls.push(String(input));
+			return respond({
+				Status: 0,
+				Answer: [{ type: 16, data: '"vigil-verify=token"' }]
+			});
+		}) as typeof fetch;
+
+		const txts = await lookupTxt('_vigil-challenge.example.com');
+		expect(txts).toEqual(['vigil-verify=token']);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toContain('cloudflare-dns.com');
+	});
+
+	it('falls back to Google when Cloudflare returns Status != 0', async () => {
+		globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+			const url = String(input);
+			calls.push(url);
+			if (url.includes('cloudflare-dns.com')) {
+				return respond({ Status: 2, Answer: [] }); // SERVFAIL
+			}
+			return respond({ Status: 0, Answer: [{ type: 16, data: '"from-google"' }] });
+		}) as typeof fetch;
+
+		const txts = await lookupTxt('example.com');
+		expect(txts).toEqual(['from-google']);
+		expect(calls).toHaveLength(2);
+		expect(calls[1]).toContain('dns.google');
+	});
+
+	it('falls back to Google when Cloudflare fetch throws', async () => {
+		globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+			const url = String(input);
+			if (url.includes('cloudflare-dns.com')) throw new Error('network down');
+			return respond({ Status: 0, Answer: [{ type: 16, data: '"recovered"' }] });
+		}) as typeof fetch;
+
+		const txts = await lookupTxt('example.com');
+		expect(txts).toEqual(['recovered']);
+	});
+
+	it('throws when Google also fails (Status != 0)', async () => {
+		globalThis.fetch = vi.fn(async () =>
+			respond({ Status: 2 })
+		) as typeof fetch;
+		await expect(lookupTxt('example.com')).rejects.toThrow();
+	});
+
+	it('filters out non-TXT answers (CNAME, etc.)', async () => {
+		globalThis.fetch = vi.fn(async () =>
+			respond({
+				Status: 0,
+				Answer: [
+					{ type: 5, data: 'cname.example.com.' },
+					{ type: 16, data: '"keep-me"' }
+				]
+			})
+		) as typeof fetch;
+		expect(await lookupTxt('example.com')).toEqual(['keep-me']);
+	});
+});

--- a/web/src/lib/server/doh.ts
+++ b/web/src/lib/server/doh.ts
@@ -1,0 +1,42 @@
+interface DohAnswer {
+	type: number;
+	data: string;
+}
+
+interface DohResponse {
+	Status: number;
+	Answer?: DohAnswer[];
+}
+
+const CLOUDFLARE = 'https://cloudflare-dns.com/dns-query';
+const GOOGLE = 'https://dns.google/resolve';
+
+async function fetchDoh(base: string, name: string): Promise<DohResponse> {
+	const res = await fetch(`${base}?name=${encodeURIComponent(name)}&type=TXT`, {
+		headers: { Accept: 'application/dns-json' }
+	});
+	if (!res.ok) throw new Error(`doh fetch failed: ${res.status}`);
+	return (await res.json()) as DohResponse;
+}
+
+// "\"vigil-verify=abc\" \"def\"" → "vigil-verify=abcdef"
+// 単一 TXT record を表現する DoH の data は複数 quoted segment を空白区切りで返す
+export function unquoteTxt(data: string): string {
+	const segs = data.match(/"((?:[^"\\]|\\.)*)"/g);
+	if (!segs) return data;
+	return segs.map((s) => s.slice(1, -1).replace(/\\(.)/g, '$1')).join('');
+}
+
+export async function lookupTxt(name: string): Promise<string[]> {
+	let resp: DohResponse;
+	try {
+		resp = await fetchDoh(CLOUDFLARE, name);
+		if (resp.Status !== 0) throw new Error(`cloudflare status ${resp.Status}`);
+	} catch {
+		resp = await fetchDoh(GOOGLE, name);
+		if (resp.Status !== 0) throw new Error(`google status ${resp.Status}`);
+	}
+	return (resp.Answer ?? [])
+		.filter((a) => a.type === 16) // TXT
+		.map((a) => unquoteTxt(a.data));
+}

--- a/web/src/lib/server/domain-repo.test.ts
+++ b/web/src/lib/server/domain-repo.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createDomain,
+	deleteDomain,
+	DomainExistsError,
+	getDomain,
+	listDomains,
+	markVerified,
+	regenToken
+} from './domain-repo';
+import { putItem } from './ddb';
+
+const SKIP = !process.env.AWS_ENDPOINT_URL;
+
+describe.skipIf(SKIP)('domain-repo (DynamoDB Local)', () => {
+	const userId = `test-user-${Date.now()}`;
+
+	it('createDomain returns a row with verify_token + expires_at', async () => {
+		const hostname = `t1-${Date.now()}.example.com`;
+		const row = await createDomain(userId, hostname);
+		expect(row.hostname).toBe(hostname);
+		expect(row.verify_token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+		expect(row.verify_token_expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000));
+		expect(row.verified_at).toBeUndefined();
+		await deleteDomain(userId, hostname);
+	});
+
+	it('throws DomainExistsError on duplicate registration', async () => {
+		const hostname = `t2-${Date.now()}.example.com`;
+		await createDomain(userId, hostname);
+		await expect(createDomain(userId, hostname)).rejects.toBeInstanceOf(DomainExistsError);
+		await deleteDomain(userId, hostname);
+	});
+
+	it('listDomains excludes scanner sub-rows (DOMAIN#x#WHOIS etc.)', async () => {
+		const hostname = `t3-${Date.now()}.example.com`;
+		await createDomain(userId, hostname);
+		// scanner が将来書く想定の sub-row を直接書き込んで filter を検証
+		await putItem({
+			Item: {
+				pk: `USER#${userId}`,
+				sk: `DOMAIN#${hostname}#WHOIS`,
+				registrar: 'fake',
+				updated_at: Math.floor(Date.now() / 1000)
+			}
+		});
+
+		const rows = await listDomains(userId);
+		const hits = rows.filter((r) => r.hostname === hostname);
+		expect(hits).toHaveLength(1); // sub-row は除外される
+		expect(hits[0].hostname).toBe(hostname);
+
+		await deleteDomain(userId, hostname);
+	});
+
+	it('markVerified sets verified_at and removes verify_token', async () => {
+		const hostname = `t4-${Date.now()}.example.com`;
+		await createDomain(userId, hostname);
+		await markVerified(userId, hostname);
+		const row = await getDomain(userId, hostname);
+		expect(row?.verified_at).toBeGreaterThan(0);
+		expect(row?.verify_token).toBeUndefined();
+		expect(row?.verify_token_expires_at).toBeUndefined();
+		await deleteDomain(userId, hostname);
+	});
+
+	it('regenToken issues a fresh token and clears verified_at', async () => {
+		const hostname = `t5-${Date.now()}.example.com`;
+		const first = await createDomain(userId, hostname);
+		await markVerified(userId, hostname);
+		await regenToken(userId, hostname);
+		const row = await getDomain(userId, hostname);
+		expect(row?.verified_at).toBeUndefined();
+		expect(row?.verify_token).toBeDefined();
+		expect(row?.verify_token).not.toBe(first.verify_token);
+		await deleteDomain(userId, hostname);
+	});
+
+	it('deleteDomain removes the row', async () => {
+		const hostname = `t6-${Date.now()}.example.com`;
+		await createDomain(userId, hostname);
+		await deleteDomain(userId, hostname);
+		expect(await getDomain(userId, hostname)).toBeUndefined();
+	});
+});

--- a/web/src/lib/server/domain-repo.ts
+++ b/web/src/lib/server/domain-repo.ts
@@ -1,0 +1,89 @@
+import { deleteItem, getItem, putItem, queryItems, updateItem } from './ddb';
+import { newOpaqueId } from './pkce';
+
+const VERIFY_TTL_SEC = 3600;
+
+export interface DomainRow {
+	hostname: string;
+	created_at: number;
+	verify_token?: string;
+	verify_token_expires_at?: number;
+	verified_at?: number;
+}
+
+const userPk = (userId: string) => `USER#${userId}`;
+const domainSk = (hostname: string) => `DOMAIN#${hostname}`;
+
+export class DomainExistsError extends Error {
+	constructor() {
+		super('DOMAIN_EXISTS');
+		this.name = 'DomainExistsError';
+	}
+}
+
+export async function createDomain(userId: string, hostname: string): Promise<DomainRow> {
+	const now = Math.floor(Date.now() / 1000);
+	const token = newOpaqueId();
+	const row: DomainRow = {
+		hostname,
+		created_at: now,
+		verify_token: token,
+		verify_token_expires_at: now + VERIFY_TTL_SEC
+	};
+	try {
+		await putItem({
+			Item: { pk: userPk(userId), sk: domainSk(hostname), ...row },
+			ConditionExpression: 'attribute_not_exists(pk) AND attribute_not_exists(sk)'
+		});
+	} catch (e) {
+		if ((e as { name?: string }).name === 'ConditionalCheckFailedException')
+			throw new DomainExistsError();
+		throw e;
+	}
+	return row;
+}
+
+function pickRow(item: Record<string, unknown>): DomainRow {
+	return {
+		hostname: item.hostname as string,
+		created_at: item.created_at as number,
+		verify_token: item.verify_token as string | undefined,
+		verify_token_expires_at: item.verify_token_expires_at as number | undefined,
+		verified_at: item.verified_at as number | undefined
+	};
+}
+
+export async function listDomains(userId: string): Promise<DomainRow[]> {
+	const r = await queryItems({
+		KeyConditionExpression: 'pk = :pk AND begins_with(sk, :sk)',
+		ExpressionAttributeValues: { ':pk': userPk(userId), ':sk': 'DOMAIN#' }
+	});
+	return (r.Items ?? [])
+		// scanner が将来書く DOMAIN#<host>#WHOIS / #SSL / #DNS 等の sub-row を除外
+		.filter((it) => (it.sk as string).split('#').length === 2)
+		.map(pickRow);
+}
+
+export async function getDomain(userId: string, hostname: string): Promise<DomainRow | undefined> {
+	const r = await getItem({ Key: { pk: userPk(userId), sk: domainSk(hostname) } });
+	return r.Item ? pickRow(r.Item) : undefined;
+}
+
+export const markVerified = (userId: string, hostname: string) =>
+	updateItem({
+		Key: { pk: userPk(userId), sk: domainSk(hostname) },
+		UpdateExpression: 'SET verified_at = :n REMOVE verify_token, verify_token_expires_at',
+		ExpressionAttributeValues: { ':n': Math.floor(Date.now() / 1000) }
+	});
+
+export function regenToken(userId: string, hostname: string): Promise<unknown> {
+	const now = Math.floor(Date.now() / 1000);
+	return updateItem({
+		Key: { pk: userPk(userId), sk: domainSk(hostname) },
+		UpdateExpression: 'SET verify_token = :t, verify_token_expires_at = :e REMOVE verified_at',
+		ExpressionAttributeValues: { ':t': newOpaqueId(), ':e': now + VERIFY_TTL_SEC }
+	});
+}
+
+export const deleteDomain = (userId: string, hostname: string) =>
+	deleteItem({ Key: { pk: userPk(userId), sk: domainSk(hostname) } });

--- a/web/src/lib/server/domain-validation.test.ts
+++ b/web/src/lib/server/domain-validation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { DomainValidationError, normalizeHostname, validateHostname } from './domain-validation';
+
+describe('normalizeHostname', () => {
+	it('lowercases and strips trailing dot', () => {
+		expect(normalizeHostname('Example.COM.')).toBe('example.com');
+	});
+	it('preserves subdomains', () => {
+		expect(normalizeHostname('app.example.com')).toBe('app.example.com');
+	});
+	it('rejects empty / whitespace', () => {
+		expect(() => normalizeHostname('')).toThrow(DomainValidationError);
+		expect(() => normalizeHostname('   ')).toThrow(DomainValidationError);
+	});
+	it('rejects values with path / port / scheme baked in', () => {
+		expect(() => normalizeHostname('example.com/foo')).toThrow();
+		expect(() => normalizeHostname('example.com:8080')).toThrow();
+		expect(() => normalizeHostname('http://example.com')).toThrow();
+	});
+});
+
+describe('validateHostname', () => {
+	const cases: Array<[string, string]> = [
+		['example.com', 'example.com'],
+		['app.example.co.uk', 'app.example.co.uk'],
+		['EXAMPLE.com.', 'example.com'],
+		['xn--ls8h.example.com', 'xn--ls8h.example.com']
+	];
+	it.each(cases)('accepts %s', (input, expected) => {
+		expect(validateHostname(input)).toBe(expected);
+	});
+
+	const bad = [
+		'',
+		'.',
+		'example..com',
+		'-bad.example.com',
+		'bad-.example.com',
+		'no-tld',
+		'a'.repeat(64) + '.example.com', // label > 63
+		('a'.repeat(60) + '.').repeat(5) + 'com' // total > 253
+	];
+	it.each(bad)('rejects %s', (input) => {
+		expect(() => validateHostname(input)).toThrow(DomainValidationError);
+	});
+});

--- a/web/src/lib/server/domain-validation.ts
+++ b/web/src/lib/server/domain-validation.ts
@@ -1,0 +1,33 @@
+const HOSTNAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+export class DomainValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'DomainValidationError';
+	}
+}
+
+export function normalizeHostname(input: string): string {
+	const trimmed = input.trim().toLowerCase().replace(/\.$/, '');
+	if (!trimmed) throw new DomainValidationError('empty hostname');
+	let url: URL;
+	try {
+		url = new URL(`https://${trimmed}`);
+	} catch {
+		throw new DomainValidationError('invalid hostname');
+	}
+	// path / port / userinfo を弾く: URL parse 後の hostname のみが入力と一致すべき
+	if (url.hostname !== trimmed || url.pathname !== '/' || url.search !== '' || url.username !== '') {
+		throw new DomainValidationError('invalid hostname');
+	}
+	return url.hostname;
+}
+
+export function validateHostname(input: string): string {
+	const norm = normalizeHostname(input);
+	if (norm.length > 253) throw new DomainValidationError('hostname too long');
+	if (!HOSTNAME_RE.test(norm)) throw new DomainValidationError('invalid hostname format');
+	if (norm.split('.').some((label) => label.length > 63))
+		throw new DomainValidationError('label too long');
+	return norm;
+}

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+import { listDomains } from '$lib/server/domain-repo';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const domains = await listDomains(locals.user!.id);
+	return {
+		user: locals.user,
+		domains
+	};
+};

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,4 +1,44 @@
-<h1 class="text-2xl font-bold p-8">vigil</h1>
-<p class="px-8 text-muted-foreground">
-	Indie hacker 向けのドメイン + AWS 運用監視ダッシュボード (Phase 1: ドメイン監視)。
-</p>
+<script lang="ts">
+	import type { PageProps } from './$types';
+
+	const { data }: PageProps = $props();
+</script>
+
+<header class="flex items-baseline justify-between p-8 pb-4">
+	<h1 class="text-2xl font-bold">vigil</h1>
+	<div class="flex items-center gap-4 text-sm">
+		<span class="text-muted-foreground">@{data.user?.login}</span>
+		<form method="POST" action="/auth/logout">
+			<button class="underline">logout</button>
+		</form>
+	</div>
+</header>
+
+<main class="px-8">
+	<section class="flex items-center justify-between mb-4">
+		<h2 class="text-lg font-semibold">ドメイン</h2>
+		<a href="/domains/new" class="border rounded px-3 py-1 hover:bg-gray-50">+ 追加</a>
+	</section>
+
+	{#if data.domains.length === 0}
+		<p class="text-sm text-muted-foreground">
+			まだドメインが登録されていません。<a href="/domains/new" class="underline">登録する</a> と
+			WHOIS / SSL / DNS の監視を始めます。
+		</p>
+	{:else}
+		<ul class="divide-y border rounded">
+			{#each data.domains as d (d.hostname)}
+				<li class="flex items-center justify-between px-4 py-3">
+					<a href="/domains/{encodeURIComponent(d.hostname)}" class="font-mono">{d.hostname}</a>
+					{#if d.verified_at}
+						<span class="text-xs px-2 py-0.5 rounded bg-green-100 text-green-800">verified</span>
+					{:else}
+						<span class="text-xs px-2 py-0.5 rounded bg-yellow-100 text-yellow-800"
+							>verify pending</span
+						>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</main>

--- a/web/src/routes/domains/[domain]/+page.server.ts
+++ b/web/src/routes/domains/[domain]/+page.server.ts
@@ -1,0 +1,67 @@
+import { error, fail, redirect } from '@sveltejs/kit';
+import { lookupTxt } from '$lib/server/doh';
+import { deleteDomain, getDomain, markVerified, regenToken } from '$lib/server/domain-repo';
+import { DomainValidationError, validateHostname } from '$lib/server/domain-validation';
+import type { Actions, PageServerLoad } from './$types';
+
+function safeValidate(raw: string): string {
+	try {
+		return validateHostname(raw);
+	} catch (e) {
+		if (e instanceof DomainValidationError) error(404, 'not found');
+		throw e;
+	}
+}
+
+export const load: PageServerLoad = async ({ locals, params }) => {
+	const hostname = safeValidate(params.domain);
+	const row = await getDomain(locals.user!.id, hostname);
+	if (!row) error(404, 'not found');
+	return { domain: row };
+};
+
+export const actions: Actions = {
+	verify: async ({ locals, params }) => {
+		const hostname = safeValidate(params.domain);
+		const row = await getDomain(locals.user!.id, hostname);
+		if (!row) error(404, 'not found');
+
+		if (row.verified_at) return { ok: true, alreadyVerified: true };
+		if (!row.verify_token || !row.verify_token_expires_at) {
+			return fail(400, { error: 'token がありません。再発行してください。', expired: true });
+		}
+		if (row.verify_token_expires_at < Math.floor(Date.now() / 1000)) {
+			return fail(410, { error: 'token が期限切れです。再発行してください。', expired: true });
+		}
+
+		const expected = `vigil-verify=${row.verify_token}`;
+		let txts: string[];
+		try {
+			txts = await lookupTxt(`_vigil-challenge.${hostname}`);
+		} catch {
+			return fail(502, { error: 'DNS lookup に失敗しました。数秒待って再試行してください。' });
+		}
+
+		if (!txts.some((t) => t === expected)) {
+			return fail(400, {
+				error: 'TXT が一致しません。propagation を待って再試行してください。',
+				seen: txts
+			});
+		}
+
+		await markVerified(locals.user!.id, hostname);
+		return { ok: true };
+	},
+
+	regen: async ({ locals, params }) => {
+		const hostname = safeValidate(params.domain);
+		await regenToken(locals.user!.id, hostname);
+		return { ok: true, regenerated: true };
+	},
+
+	delete: async ({ locals, params }) => {
+		const hostname = safeValidate(params.domain);
+		await deleteDomain(locals.user!.id, hostname);
+		redirect(303, '/');
+	}
+};

--- a/web/src/routes/domains/[domain]/+page.svelte
+++ b/web/src/routes/domains/[domain]/+page.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { PageProps } from './$types';
+
+	const { data, form }: PageProps = $props();
+</script>
+
+<header class="p-8 pb-4">
+	<a href="/" class="text-sm underline text-muted-foreground">← ダッシュボード</a>
+	<h1 class="text-2xl font-bold mt-2 font-mono">{data.domain.hostname}</h1>
+</header>
+
+<main class="px-8 flex flex-col gap-6 max-w-2xl">
+	{#if data.domain.verified_at}
+		<section class="flex items-center gap-3">
+			<span class="text-xs px-2 py-0.5 rounded bg-green-100 text-green-800">verified</span>
+			<span class="text-sm text-muted-foreground"
+				>at {new Date(data.domain.verified_at * 1000).toISOString()}</span
+			>
+		</section>
+	{:else}
+		<section>
+			<h2 class="text-lg font-semibold mb-2">DNS TXT 所有確認</h2>
+			<p class="text-sm text-muted-foreground mb-3">
+				以下の TXT レコードを設定し、propagation 後 (15〜60s 程度) に「Verify」を押してください。
+			</p>
+			<pre
+				class="border rounded p-3 bg-gray-50 text-xs font-mono whitespace-pre overflow-x-auto">Name:  _vigil-challenge.{data.domain.hostname}
+Type:  TXT
+Value: vigil-verify={data.domain.verify_token}</pre>
+			{#if data.domain.verify_token_expires_at}
+				<p class="text-xs text-muted-foreground mt-2">
+					token 有効期限: {new Date(data.domain.verify_token_expires_at * 1000).toLocaleString()}
+				</p>
+			{/if}
+			<div class="flex gap-3 mt-4">
+				<form method="POST" action="?/verify" use:enhance>
+					<button class="border rounded px-3 py-1 bg-black text-white hover:bg-gray-800"
+						>Verify</button
+					>
+				</form>
+				{#if form && 'expired' in form && form.expired}
+					<form method="POST" action="?/regen" use:enhance>
+						<button class="border rounded px-3 py-1 hover:bg-gray-50">token 再発行</button>
+					</form>
+				{/if}
+			</div>
+			{#if form && 'error' in form && form.error}
+				<p class="text-sm text-red-600 mt-3">{form.error}</p>
+				{#if 'seen' in form && Array.isArray(form.seen) && form.seen.length > 0}
+					<details class="text-xs text-muted-foreground mt-2">
+						<summary>取得した TXT 値 ({form.seen.length} 件)</summary>
+						<ul class="font-mono mt-1">
+							{#each form.seen as v (v)}<li>{v}</li>{/each}
+						</ul>
+					</details>
+				{/if}
+			{/if}
+			{#if form && 'regenerated' in form && form.regenerated}
+				<p class="text-sm text-green-700 mt-3">
+					新しい token を発行しました。再度 Verify してください。
+				</p>
+			{/if}
+		</section>
+	{/if}
+
+	<section class="border-t pt-6">
+		<h2 class="text-sm font-semibold text-red-700 mb-2">削除</h2>
+		<p class="text-xs text-muted-foreground mb-3">
+			このドメインを vigil の監視対象から外します (DNS 設定や WHOIS には影響しません)。
+		</p>
+		<form method="POST" action="?/delete" use:enhance>
+			<button class="border border-red-300 text-red-700 rounded px-3 py-1 hover:bg-red-50"
+				>Delete</button
+			>
+		</form>
+	</section>
+</main>

--- a/web/src/routes/domains/new/+page.server.ts
+++ b/web/src/routes/domains/new/+page.server.ts
@@ -1,0 +1,29 @@
+import { fail, redirect, type Actions } from '@sveltejs/kit';
+import { createDomain, DomainExistsError } from '$lib/server/domain-repo';
+import { DomainValidationError, validateHostname } from '$lib/server/domain-validation';
+
+export const actions: Actions = {
+	default: async ({ request, locals }) => {
+		const fd = await request.formData();
+		const raw = String(fd.get('hostname') ?? '');
+
+		let hostname: string;
+		try {
+			hostname = validateHostname(raw);
+		} catch (e) {
+			const message = e instanceof DomainValidationError ? e.message : 'invalid hostname';
+			return fail(400, { hostname: raw, error: `無効なドメイン名です (${message})` });
+		}
+
+		try {
+			await createDomain(locals.user!.id, hostname);
+		} catch (e) {
+			if (e instanceof DomainExistsError) {
+				return fail(409, { hostname: raw, error: '既に登録済みです' });
+			}
+			throw e;
+		}
+
+		redirect(303, `/domains/${encodeURIComponent(hostname)}`);
+	}
+};

--- a/web/src/routes/domains/new/+page.svelte
+++ b/web/src/routes/domains/new/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { PageProps } from './$types';
+
+	const { form }: PageProps = $props();
+</script>
+
+<header class="p-8 pb-4">
+	<a href="/" class="text-sm underline text-muted-foreground">← ダッシュボード</a>
+	<h1 class="text-2xl font-bold mt-2">ドメインを追加</h1>
+</header>
+
+<main class="px-8">
+	<form method="POST" use:enhance class="flex flex-col gap-3 max-w-md">
+		<label class="flex flex-col gap-1">
+			<span class="text-sm">hostname</span>
+			<input
+				name="hostname"
+				type="text"
+				required
+				placeholder="example.com"
+				value={form?.hostname ?? ''}
+				class="border rounded px-3 py-2 font-mono"
+			/>
+		</label>
+		{#if form?.error}
+			<p class="text-sm text-red-600">{form.error}</p>
+		{/if}
+		<button class="border rounded px-3 py-2 bg-black text-white hover:bg-gray-800">登録する</button>
+	</form>
+	<p class="text-xs text-muted-foreground mt-4 max-w-md">
+		登録後に表示される TXT レコードを <code>_vigil-challenge.&lt;hostname&gt;</code> に設定し、
+		propagation 後に「Verify」ボタンを押してください。
+	</p>
+</main>


### PR DESCRIPTION
## Summary

ユーザーが自分の所有ドメインを登録 → DNS TXT で所有確認 → 監視対象に乗せるフローを通した。Issue #11/12/13 で骨格・永続化・認証が揃った上に乗る vigil の **コア機能の入口**。

### フロー

1. ホーム = ダッシュボードでドメイン一覧 (verified / verify pending バッジ)
2. 「+ 追加」→ hostname 入力 → 登録 (token 自動発行、TTL 1h)
3. 詳細画面に表示: \`Name: _vigil-challenge.<host> / Type: TXT / Value: vigil-verify=<token>\`
4. ユーザー DNS 設定 → propagation 待ち (15〜60s)
5. 「Verify」押下 → DoH (Cloudflare → Google fallback) で TXT 取得 → token 一致なら verified
6. 期限切れなら「再発行」、不要なら「Delete」

## 実装

### Helpers (\`web/src/lib/server/\`)
- \`domain-validation.ts\` — \`normalizeHostname\` + \`validateHostname\` (URL constructor で path/port 弾き、regex + label/total 長、\`DomainValidationError\` を export)
- \`doh.ts\` — \`lookupTxt\` (Cloudflare primary + Google fallback)、quoted-segment の連結 (\`unquoteTxt\`)
- \`domain-repo.ts\` — \`createDomain\` (Conditional put で重複防止 → \`DomainExistsError\`)、\`getDomain\` / \`listDomains\` (sub-row 除外) / \`markVerified\` / \`regenToken\` / \`deleteDomain\`。token は \`pkce.ts\` の \`newOpaqueId\` (32B base64url) を流用

### Routes
- \`/+page.{server.ts,svelte}\` — dashboard 化、verified/pending バッジ + 「+ 追加」リンク + logout
- \`/domains/new\` — 登録 form。\`validate → createDomain → redirect\`。エラーは \`fail(400/409)\` でフォーム表示
- \`/domains/[domain]\` — 詳細 + TXT 表示 + named action \`verify\` / \`regen\` / \`delete\`。\`verify\` は token 直接比較、期限切れ \`fail(410, { expired: true })\` で UI に再発行ボタン

### Tests (vitest)
- \`domain-validation.test.ts\` — 正常 4 + 異常 9 ケース (空、ダブルドット、長すぎる label/total)
- \`doh.test.ts\` — fetch mock で CF 成功 / CF→Google fallback (Status≠0) / fetch throw / 全部失敗 / 非 TXT (CNAME) フィルタ
- \`domain-repo.test.ts\` — DynamoDB Local 前提。create / 重複時 \`DomainExistsError\` / list (sub-row 除外検証) / markVerified / regenToken / delete

## 動作確認 (実施済み)

- [x] \`pnpm -C web check\` 0 エラー
- [x] \`pnpm -C web test\` **42/42 pass** (既存 12 + 新規 30)
- [x] dev server (\`AWS_ENDPOINT_URL=http://127.0.0.1:8000 pnpm dev\`) で curl 経由のフロー確認
  - 未認証で \`/\` / \`/domains/new\` / \`/domains/<host>\` 全部 \`303 → /auth/github?next=...\`
  - DDB に session を直接書いて authed 状態でアクセス → ホームに dashboard、空メッセージ表示
  - \`POST /domains/new\` (form action) → 200 OK + JSON
  - 一覧に登録ドメインが \`verify pending\` バッジ付きで表示
  - 詳細画面に \`_vigil-challenge.<host>\` + \`vigil-verify=<token>\` + Verify ボタン

## 残タスク (この PR では対応しない)

- WHOIS / SSL / DNS scanner は **#15-#17** (DOMAIN 行と同じ pk で sub-row として書く想定、\`listDomains\` は sk の \`#\` 数で除外済み)
- ダッシュボード UI 仕上げ (shadcn-svelte) は **#20**
- E2E (form フロー全体) は **#26**
- \`docs/design/03-domain-verification.md\` 更新は **#29**

## 既知の留意点

- token 漏洩面を減らすため verified 後は \`verify_token\` / \`verify_token_expires_at\` を \`REMOVE\`
- \`listDomains\` の sub-row 除外は app 側 \`sk.split('#').length === 2\` フィルタ。scanner で sub-row prefix を別 (\`WHOIS#<host>\` 等) に変える選択肢もあるが master plan の schema を尊重
- DoH free tier の rate limit は user × hostname × ボタン押下なので問題なし。bot 防御は将来別 issue で
- shadcn-svelte は #20 まで待ち、本 issue は素 HTML + Tailwind v4 ユーティリティのみ

## Closes

Closes #14