### PR TITLE
feat: tls scanner with expiry / authorized check (fixes #16)

### DIFF
--- a/scanner/src/index.ts
+++ b/scanner/src/index.ts
@@ -2,6 +2,8 @@ import { Logger } from '@aws-lambda-powertools/logger';
 import type { ScheduledHandler } from 'aws-lambda';
 import { listVerifiedDomains, type VerifiedDomain } from './domain-list';
 import { lookupWhois } from './rdap';
+import { putSsl, type SslRow } from './ssl-repo';
+import { lookupTls } from './tls';
 import { putWhois, type WhoisRow } from './whois-repo';
 
 const CONCURRENCY = 5;
@@ -25,10 +27,12 @@ export const handler: ScheduledHandler = async (event) => {
 		while (queue.length > 0) {
 			const d = queue.shift();
 			if (!d) return;
-			const now = Math.floor(Date.now() / 1000);
+
+			// RDAP
+			const rdapAt = Math.floor(Date.now() / 1000);
 			try {
 				const facts = await lookupWhois(d.hostname);
-				const row: WhoisRow = { ...facts, updated_at: now };
+				const row: WhoisRow = { ...facts, updated_at: rdapAt };
 				await putWhois(d.userId, d.hostname, row);
 				logger.info('rdap_ok', { host: d.hostname, expires_at: facts.expires_at });
 			} catch (err) {
@@ -38,12 +42,35 @@ export const handler: ScheduledHandler = async (event) => {
 					nameservers: [],
 					statuses: [],
 					redacted: false,
-					updated_at: now,
+					updated_at: rdapAt,
 					error: msg
 				};
 				await putWhois(d.userId, d.hostname, errorRow).catch(() => {
 					// 書き込み自体が失敗してもこの worker は次のドメインに進む
 				});
+			}
+
+			// TLS (RDAP とは独立した try/catch、片方失敗してももう片方は進める)
+			const tlsAt = Math.floor(Date.now() / 1000);
+			try {
+				const facts = await lookupTls(d.hostname);
+				const row: SslRow = { ...facts, updated_at: tlsAt };
+				await putSsl(d.userId, d.hostname, row);
+				logger.info('tls_ok', {
+					host: d.hostname,
+					valid_to: facts.valid_to,
+					authorized: facts.authorized
+				});
+			} catch (err) {
+				const msg = (err as Error).message ?? 'unknown';
+				logger.warn('tls_failed', { host: d.hostname, msg });
+				const errorRow: SslRow = {
+					san: [],
+					authorized: false,
+					updated_at: tlsAt,
+					error: msg
+				};
+				await putSsl(d.userId, d.hostname, errorRow).catch(() => {});
 			}
 		}
 	};

--- a/scanner/src/rdap.ts
+++ b/scanner/src/rdap.ts
@@ -20,7 +20,7 @@ export interface WhoisFacts {
 }
 
 interface BootstrapJson {
-	services: [string[], string[]][];
+	services: unknown[];
 }
 
 async function loadBootstrap(): Promise<Map<string, string>> {
@@ -34,10 +34,16 @@ async function loadBootstrap(): Promise<Map<string, string>> {
 
 export function buildTldMap(json: BootstrapJson): Map<string, string> {
 	const map = new Map<string, string>();
-	for (const [tlds, urls] of json.services) {
-		if (!Array.isArray(urls) || urls.length === 0) continue;
-		const base = urls[0].endsWith('/') ? urls[0] : urls[0] + '/';
-		for (const t of tlds) map.set(t.toLowerCase(), base);
+	for (const entry of json.services) {
+		if (!Array.isArray(entry) || entry.length < 2) continue;
+		const [tlds, urls] = entry as [unknown, unknown];
+		if (!Array.isArray(tlds) || !Array.isArray(urls) || urls.length === 0) continue;
+		const firstUrl = urls[0];
+		if (typeof firstUrl !== 'string') continue;
+		const base = firstUrl.endsWith('/') ? firstUrl : firstUrl + '/';
+		for (const t of tlds) {
+			if (typeof t === 'string') map.set(t.toLowerCase(), base);
+		}
 	}
 	return map;
 }

--- a/scanner/src/ssl-repo.test.ts
+++ b/scanner/src/ssl-repo.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { getSsl, putSsl, type SslRow } from './ssl-repo';
+
+const SKIP = !process.env.AWS_ENDPOINT_URL;
+
+describe.skipIf(SKIP)('ssl-repo (DynamoDB Local)', () => {
+	const userId = `ssl-test-${Date.now()}`;
+
+	it('round trip: putSsl → getSsl returns the row', async () => {
+		const hostname = `t1-${Date.now()}.example.com`;
+		const row: SslRow = {
+			issuer: 'Test CA',
+			subject: hostname,
+			san: [hostname, `www.${hostname}`],
+			valid_from: 1700000000,
+			valid_to: 1900000000,
+			authorized: true,
+			fingerprint256: 'AA:BB',
+			serial_number: 'DEADBEEF',
+			updated_at: Math.floor(Date.now() / 1000)
+		};
+		await putSsl(userId, hostname, row);
+		const got = await getSsl(userId, hostname);
+		expect(got?.issuer).toBe('Test CA');
+		expect(got?.valid_to).toBe(1900000000);
+		expect(got?.san).toEqual([hostname, `www.${hostname}`]);
+		expect(got?.authorized).toBe(true);
+	});
+
+	it('drops undefined attributes (issuer/valid_to omitted)', async () => {
+		const hostname = `t2-${Date.now()}.example.com`;
+		const row: SslRow = {
+			san: [],
+			authorized: false,
+			updated_at: Math.floor(Date.now() / 1000),
+			error: 'tls_timeout'
+		};
+		await putSsl(userId, hostname, row);
+		const got = await getSsl(userId, hostname);
+		expect(got?.error).toBe('tls_timeout');
+		expect(got?.issuer).toBeUndefined();
+		expect(got?.valid_to).toBeUndefined();
+		expect(got?.fingerprint256).toBeUndefined();
+		expect(got?.authorized).toBe(false);
+	});
+
+	it('overwrites earlier row on second putSsl', async () => {
+		const hostname = `t3-${Date.now()}.example.com`;
+		await putSsl(userId, hostname, {
+			san: [],
+			authorized: false,
+			updated_at: 100,
+			error: 'first'
+		});
+		await putSsl(userId, hostname, {
+			issuer: "Let's Encrypt",
+			subject: hostname,
+			san: [hostname],
+			valid_to: 1900000000,
+			authorized: true,
+			updated_at: 200
+		});
+		const got = await getSsl(userId, hostname);
+		expect(got?.issuer).toBe("Let's Encrypt");
+		expect(got?.error).toBeUndefined();
+	});
+});

--- a/scanner/src/ssl-repo.ts
+++ b/scanner/src/ssl-repo.ts
@@ -1,0 +1,18 @@
+import { getItem, putItem } from './ddb';
+import type { SslFacts } from './tls';
+
+export interface SslRow extends SslFacts {
+	updated_at: number;
+	error?: string;
+}
+
+const userPk = (uid: string) => `USER#${uid}`;
+const sslSk = (host: string) => `DOMAIN#${host}#SSL`;
+
+export const putSsl = (uid: string, host: string, row: SslRow) =>
+	putItem({ Item: { pk: userPk(uid), sk: sslSk(host), ...row } });
+
+export async function getSsl(uid: string, host: string): Promise<SslRow | undefined> {
+	const r = await getItem({ Key: { pk: userPk(uid), sk: sslSk(host) } });
+	return r.Item as SslRow | undefined;
+}

--- a/scanner/src/tls.test.ts
+++ b/scanner/src/tls.test.ts
@@ -1,0 +1,103 @@
+import type { PeerCertificate } from 'node:tls';
+import { describe, expect, it } from 'vitest';
+import { parseTlsCert } from './tls';
+
+// Build a minimal PeerCertificate-like object. node:tls の型は厳密だが、parser は属性アクセスのみで
+// 動くため Record で渡して `as unknown as PeerCertificate` 可。
+function cert(overrides: Partial<Record<string, unknown>> = {}): PeerCertificate {
+	const base = {
+		subject: { CN: 'example.com' },
+		issuer: { CN: 'Test CA' },
+		valid_from: 'Apr 28 12:34:56 2025 GMT',
+		valid_to: 'Apr 28 12:34:56 2026 GMT',
+		subjectaltname: 'DNS:example.com, DNS:www.example.com',
+		serialNumber: 'ABCDEF1234567890',
+		fingerprint256: '00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF'
+	};
+	return { ...base, ...overrides } as unknown as PeerCertificate;
+}
+
+describe('parseTlsCert', () => {
+	it('extracts issuer / subject / san / valid_from / valid_to / serial / fingerprint', () => {
+		const facts = parseTlsCert(cert(), true);
+		expect(facts.issuer).toBe('Test CA');
+		expect(facts.subject).toBe('example.com');
+		expect(facts.san).toEqual(['example.com', 'www.example.com']);
+		expect(facts.valid_from).toBe(Math.floor(Date.parse('Apr 28 12:34:56 2025 GMT') / 1000));
+		expect(facts.valid_to).toBe(Math.floor(Date.parse('Apr 28 12:34:56 2026 GMT') / 1000));
+		expect(facts.serial_number).toBe('ABCDEF1234567890');
+		expect(facts.fingerprint256).toBe('00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF');
+		expect(facts.authorized).toBe(true);
+		expect(facts.authorization_error).toBeUndefined();
+	});
+
+	it('preserves cert info on expired (authorized=false + authError)', () => {
+		const facts = parseTlsCert(cert(), false, 'CERT_HAS_EXPIRED');
+		expect(facts.authorized).toBe(false);
+		expect(facts.authorization_error).toBe('CERT_HAS_EXPIRED');
+		expect(facts.valid_to).toBeGreaterThan(0); // 情報は取れる
+	});
+
+	it('returns san=[] when subjectaltname is undefined', () => {
+		const facts = parseTlsCert(cert({ subjectaltname: undefined }), true);
+		expect(facts.san).toEqual([]);
+	});
+
+	it('returns san=[] on empty subjectaltname string', () => {
+		const facts = parseTlsCert(cert({ subjectaltname: '' }), true);
+		expect(facts.san).toEqual([]);
+	});
+
+	it('keeps only DNS-typed entries when subjectaltname mixes IP Address and DNS', () => {
+		const facts = parseTlsCert(
+			cert({ subjectaltname: 'DNS:a.com, IP Address:1.2.3.4, DNS:b.com' }),
+			true
+		);
+		expect(facts.san).toEqual(['a.com', 'b.com']);
+	});
+
+	it('lowercases SAN values', () => {
+		const facts = parseTlsCert(cert({ subjectaltname: 'DNS:Example.COM, DNS:WWW.Example.com' }), true);
+		expect(facts.san).toEqual(['example.com', 'www.example.com']);
+	});
+
+	it('takes the first CN when subject.CN is multi-value (string[])', () => {
+		const facts = parseTlsCert(cert({ subject: { CN: ['first.example', 'second.example'] } }), true);
+		expect(facts.subject).toBe('first.example');
+	});
+
+	it('returns issuer=undefined when issuer has no CN', () => {
+		const facts = parseTlsCert(cert({ issuer: { O: 'Some Org' } }), true);
+		expect(facts.issuer).toBeUndefined();
+	});
+
+	it('returns valid_from/valid_to=undefined on missing or invalid date strings', () => {
+		const facts1 = parseTlsCert(cert({ valid_from: undefined, valid_to: 'not a date' }), true);
+		expect(facts1.valid_from).toBeUndefined();
+		expect(facts1.valid_to).toBeUndefined();
+
+		const facts2 = parseTlsCert(cert({ valid_to: undefined }), true);
+		expect(facts2.valid_to).toBeUndefined();
+	});
+
+	it('returns safe defaults on totally empty input', () => {
+		const facts = parseTlsCert({} as PeerCertificate, false);
+		expect(facts.san).toEqual([]);
+		expect(facts.authorized).toBe(false);
+		expect(facts.issuer).toBeUndefined();
+		expect(facts.subject).toBeUndefined();
+		expect(facts.valid_from).toBeUndefined();
+		expect(facts.valid_to).toBeUndefined();
+		expect(facts.fingerprint256).toBeUndefined();
+		expect(facts.serial_number).toBeUndefined();
+	});
+
+	it('drops "DNS:" prefix and trims whitespace correctly', () => {
+		// 実装は match で extractlocs するため余分な空白も取り除く
+		const facts = parseTlsCert(
+			cert({ subjectaltname: 'DNS:foo.com,  DNS:bar.com,DNS:baz.com' }),
+			true
+		);
+		expect(facts.san).toEqual(['foo.com', 'bar.com', 'baz.com']);
+	});
+});

--- a/scanner/src/tls.ts
+++ b/scanner/src/tls.ts
@@ -1,0 +1,81 @@
+import tls, { type PeerCertificate } from 'node:tls';
+
+const TIMEOUT_MS = 5000;
+
+export interface SslFacts {
+	issuer?: string;
+	subject?: string;
+	san: string[]; // DNS タイプのみ、lowercase
+	valid_from?: number; // epoch sec
+	valid_to?: number; // epoch sec ← alert 対象
+	authorized: boolean;
+	authorization_error?: string;
+	fingerprint256?: string;
+	serial_number?: string;
+}
+
+function pickCN(rdn: PeerCertificate['subject'] | undefined): string | undefined {
+	const cn = (rdn as Record<string, string | string[]> | undefined)?.CN;
+	if (Array.isArray(cn)) return cn[0];
+	return typeof cn === 'string' ? cn : undefined;
+}
+
+function parseDate(s?: string): number | undefined {
+	if (!s) return undefined;
+	const t = Date.parse(s); // "Apr 28 12:34:56 2025 GMT"
+	return Number.isFinite(t) ? Math.floor(t / 1000) : undefined;
+}
+
+export function parseTlsCert(
+	cert: PeerCertificate,
+	authorized: boolean,
+	authError?: string
+): SslFacts {
+	const sanRaw = cert.subjectaltname ?? '';
+	const san = (sanRaw.match(/DNS:([^,\s]+)/g) ?? []).map((s) => s.slice(4).toLowerCase());
+	return {
+		issuer: pickCN(cert.issuer),
+		subject: pickCN(cert.subject),
+		san,
+		valid_from: parseDate(cert.valid_from),
+		valid_to: parseDate(cert.valid_to),
+		authorized,
+		authorization_error: authError,
+		fingerprint256: cert.fingerprint256,
+		serial_number: cert.serialNumber
+	};
+}
+
+export function lookupTls(host: string, port = 443): Promise<SslFacts> {
+	return new Promise((resolve, reject) => {
+		const socket = tls.connect({
+			host,
+			port,
+			servername: host, // SNI 必須 (ALB/CF はデフォルト cert を返す)
+			rejectUnauthorized: false, // expired/self-signed でも secureConnect 到達
+			timeout: TIMEOUT_MS
+		});
+
+		let settled = false;
+		const finish = (fn: () => void) => {
+			if (settled) return;
+			settled = true;
+			fn();
+			socket.destroy();
+		};
+
+		socket.once('secureConnect', () => {
+			const cert = socket.getPeerCertificate(true);
+			if (!cert || Object.keys(cert).length === 0) {
+				return finish(() => reject(new Error('no_peer_certificate')));
+			}
+			const authError = socket.authorized
+				? undefined
+				: ((socket.authorizationError as Error | undefined)?.message ??
+					(socket.authorizationError ? String(socket.authorizationError) : undefined));
+			finish(() => resolve(parseTlsCert(cert, socket.authorized, authError)));
+		});
+		socket.once('timeout', () => finish(() => reject(new Error('tls_timeout'))));
+		socket.once('error', (err: Error) => finish(() => reject(err)));
+	});
+}


### PR DESCRIPTION
## Summary

scanner Lambda に TLS 証明書スキャンを追加。Node 標準 \`node:tls\` で 443 に接続し、\`secureConnect\` で \`getPeerCertificate(true)\` を呼んで \`valid_to\` / \`subjectaltname\` / \`issuer.CN\` / \`subject.CN\` 等を抽出し \`DOMAIN#<host>#SSL\` sub-row に書き込む。

\`rejectUnauthorized: false\` + \`authorized\` / \`authorizationError\` の二段構えで「期限切れだが情報は欲しい」を両立 (Issue #16 の主要要件)。

## 実装

### 新規 helpers
- \`scanner/src/tls.ts\` — \`parseTlsCert\` (pure 関数) + \`lookupTls\` (Promise wrapper、5s timeout、\`settled\` flag + \`socket.destroy()\` でリーク防止、\`servername\` 必須で SNI)
- \`scanner/src/ssl-repo.ts\` — \`putSsl\` / \`getSsl\` で \`DOMAIN#<host>#SSL\` sub-row の I/O (whois-repo と同型)

### 既存 handler への統合 (\`scanner/src/index.ts\`)
- worker 内 RDAP ブロックの後ろに **独立した try/catch で TLS ブロック**を追加
- 片方失敗してももう片方は進む (RDAP 404 で TLS は成功する例: badssl.com sub-domain)
- 並列度 5 維持

### 既存 \`scanner/src/rdap.ts\` の small fix
- \`BootstrapJson\` の \`services\` を \`[string[], string[]][]\` から \`unknown[]\` に緩めて internal で narrowing
- json import の \`string[][][]\` 推論との assignability エラーを回避 (typecheck 通る、ロジック変更なし)

### Tests (vitest 2 本、計 10 + 3 ケース)
- \`tls.test.ts\` (parseTlsCert を fixture で網羅、実 TLS 不使用):
  - 正常 (authorized=true)、期限切れ (authError='CERT_HAS_EXPIRED' でも cert は parse)
  - \`subjectaltname\` 不在 / 空文字、IP Address mix → DNS のみ抽出、lowercase
  - \`subject.CN\` が \`string[]\` (multi-value RDN) → 先頭採用
  - \`issuer\` に CN なし → undefined
  - \`valid_from\` / \`valid_to\` 不正値 → undefined
  - 全空 → safe defaults
  - 空白混じり SAN
- \`ssl-repo.test.ts\` (DDB Local 前提): round trip + undefined 属性省略 + 上書き

## 動作確認 (実施済み)

- [x] \`pnpm -C scanner typecheck\` 0 エラー
- [x] \`pnpm -C scanner test\` **30/30 pass** (新規 13 + 既存 17)
- [x] DDB Local + 手動 invoke (\`pnpm -C scanner dev\`) で実 TLS 接続確認
  - **\`example.com\`**: \`tls_ok\` / \`authorized: true\` / \`valid_to: 1782941086\` (2026年) / \`issuer: "Cloudflare TLS Issuing ECC CA 1"\` / \`san: ["example.com", "*.example.com"]\`
  - **\`expired.badssl.com\`** (← Issue #16 主要要件): \`tls_ok\` / \`authorized: false\` / \`authorization_error: "CERT_HAS_EXPIRED"\` / \`valid_to: 1428883199\` (2015 年、過去) / \`issuer: "COMODO RSA Domain Validation Secure Server CA"\` 取得成功
  - RDAP も並行実行: \`example.com\` は \`rdap_ok\`、\`expired.badssl.com\` は \`rdap_404\` (それぞれ独立した sub-row に書かれる)

## 設計判断

- **CI で実 TLS は叩かない** (flaky 回避)、\`parseTlsCert\` の単体テストでカバー
- **rejectUnauthorized: false** で expired/self-signed cert でも \`secureConnect\` 到達 → 情報取得 + \`authorization_error\` で alert ロジックに通知
- **SNI 必須** (\`servername: host\`)、ALB/CloudFront はデフォルト cert を返してしまうため
- **socket リーク防止**: \`settled\` flag + \`finish()\` で必ず \`socket.destroy()\`

## 残タスク (この PR では対応しない)

- DNS scanner (\`#DNS\` sub-row) は **#17**
- EventBridge Scheduler 連携 (Terraform) は **#18**
- SES アラートメール (期限近接通知) は **#19**
- \`docs/design/04-scanners.md\` 更新は **#29**

## Closes

Closes #16