### PR TITLE
feat: dns scanner with doh + dnssec ad flag (fixes #17)

### DIFF
--- a/scanner/src/dns-repo.test.ts
+++ b/scanner/src/dns-repo.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getDns, putDns, type DnsRow } from './dns-repo';
+
+const SKIP = !process.env.AWS_ENDPOINT_URL;
+
+describe.skipIf(SKIP)('dns-repo (DynamoDB Local)', () => {
+	const userId = `dns-test-${Date.now()}`;
+
+	it('round trip: putDns → getDns returns the row', async () => {
+		const hostname = `t1-${Date.now()}.example.com`;
+		const row: DnsRow = {
+			a: ['1.2.3.4'],
+			aaaa: ['2001:db8::1'],
+			ns: ['ns1.example.com', 'ns2.example.com'],
+			mx: [{ priority: 10, exchange: 'mail.example.com' }],
+			txt: ['v=spf1 -all'],
+			soa: 'ns1.example.com. hostmaster. 1 7200 3600 1209600 3600',
+			caa: ['0 issue "letsencrypt.org"'],
+			dnssec_ad: true,
+			updated_at: Math.floor(Date.now() / 1000)
+		};
+		await putDns(userId, hostname, row);
+		const got = await getDns(userId, hostname);
+		expect(got?.a).toEqual(['1.2.3.4']);
+		expect(got?.mx).toEqual([{ priority: 10, exchange: 'mail.example.com' }]);
+		expect(got?.dnssec_ad).toBe(true);
+		expect(got?.soa).toBe('ns1.example.com. hostmaster. 1 7200 3600 1209600 3600');
+	});
+
+	it('drops undefined attributes (soa omitted, error stored)', async () => {
+		const hostname = `t2-${Date.now()}.example.com`;
+		const row: DnsRow = {
+			a: [],
+			aaaa: [],
+			ns: [],
+			mx: [],
+			txt: [],
+			caa: [],
+			dnssec_ad: false,
+			updated_at: Math.floor(Date.now() / 1000),
+			error: 'doh 503'
+		};
+		await putDns(userId, hostname, row);
+		const got = await getDns(userId, hostname);
+		expect(got?.error).toBe('doh 503');
+		expect(got?.soa).toBeUndefined();
+		expect(got?.a).toEqual([]);
+		expect(got?.dnssec_ad).toBe(false);
+	});
+
+	it('overwrites earlier row on second putDns', async () => {
+		const hostname = `t3-${Date.now()}.example.com`;
+		await putDns(userId, hostname, {
+			a: [], aaaa: [], ns: [], mx: [], txt: [], caa: [],
+			dnssec_ad: false, updated_at: 100, error: 'first'
+		});
+		await putDns(userId, hostname, {
+			a: ['9.9.9.9'], aaaa: [], ns: [], mx: [], txt: [], caa: [],
+			dnssec_ad: true, updated_at: 200
+		});
+		const got = await getDns(userId, hostname);
+		expect(got?.a).toEqual(['9.9.9.9']);
+		expect(got?.error).toBeUndefined();
+	});
+});

--- a/scanner/src/dns-repo.ts
+++ b/scanner/src/dns-repo.ts
@@ -1,0 +1,18 @@
+import { getItem, putItem } from './ddb';
+import type { DnsFacts } from './doh';
+
+export interface DnsRow extends DnsFacts {
+	updated_at: number;
+	error?: string;
+}
+
+const userPk = (uid: string) => `USER#${uid}`;
+const dnsSk = (host: string) => `DOMAIN#${host}#DNS`;
+
+export const putDns = (uid: string, host: string, row: DnsRow) =>
+	putItem({ Item: { pk: userPk(uid), sk: dnsSk(host), ...row } });
+
+export async function getDns(uid: string, host: string): Promise<DnsRow | undefined> {
+	const r = await getItem({ Key: { pk: userPk(uid), sk: dnsSk(host) } });
+	return r.Item as DnsRow | undefined;
+}

--- a/scanner/src/doh.test.ts
+++ b/scanner/src/doh.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { lookupDns, parseMx, unquoteTxt } from './doh';
+
+const realFetch = globalThis.fetch;
+
+const json = (body: unknown, init: ResponseInit = {}) =>
+	new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { 'content-type': 'application/json' },
+		...init
+	});
+
+// host & type に応じた response を返す mock factory
+type Responder = (url: string) => Response | Promise<Response>;
+
+function setFetch(responder: Responder) {
+	globalThis.fetch = vi.fn(async (input: string | URL | Request) =>
+		responder(String(input))
+	) as typeof fetch;
+}
+
+afterEach(() => {
+	globalThis.fetch = realFetch;
+	vi.restoreAllMocks();
+	vi.useRealTimers();
+});
+
+describe('unquoteTxt', () => {
+	it('joins multiple quoted segments', () => {
+		expect(unquoteTxt('"vigil-verify=abc" "def"')).toBe('vigil-verify=abcdef');
+	});
+	it('returns input as-is when no quotes', () => {
+		expect(unquoteTxt('plain')).toBe('plain');
+	});
+});
+
+describe('parseMx', () => {
+	it('parses "10 mail.example.com." to {priority, exchange}', () => {
+		expect(parseMx('10 mail.example.com.')).toEqual({ priority: 10, exchange: 'mail.example.com' });
+	});
+	it('lowercases exchange', () => {
+		expect(parseMx('5 MAIL.example.COM.')).toEqual({ priority: 5, exchange: 'mail.example.com' });
+	});
+	it('returns undefined on malformed input', () => {
+		expect(parseMx('garbage')).toBeUndefined();
+		expect(parseMx('10mail.example.com')).toBeUndefined();
+	});
+});
+
+describe('lookupDns', () => {
+	function answer(type: number, data: string) {
+		return { type, data };
+	}
+
+	it('parses A / AAAA / NS / MX / TXT / SOA / CAA from Cloudflare 200 responses', async () => {
+		setFetch((url) => {
+			if (!url.includes('cloudflare-dns.com')) throw new Error('should not fall back');
+			const t = Number(new URL(url).searchParams.get('type'));
+			const map: Record<number, unknown> = {
+				1: { Status: 0, AD: true, Answer: [answer(1, '1.2.3.4'), answer(1, '5.6.7.8')] },
+				28: { Status: 0, AD: true, Answer: [answer(28, '2001:db8::1')] },
+				2: {
+					Status: 0,
+					AD: true,
+					Answer: [answer(2, 'ns1.example.com.'), answer(2, 'NS2.example.COM.')]
+				},
+				15: { Status: 0, AD: true, Answer: [answer(15, '10 mail.example.com.')] },
+				16: { Status: 0, AD: true, Answer: [answer(16, '"hello" "world"')] },
+				6: {
+					Status: 0,
+					AD: true,
+					Answer: [answer(6, 'ns1.example.com. hostmaster.example.com. 1 7200 3600 1209600 3600')]
+				},
+				257: { Status: 0, AD: true, Answer: [answer(257, '0 issue "letsencrypt.org"')] }
+			};
+			return json(map[t] ?? { Status: 3, AD: true, Answer: [] });
+		});
+
+		const facts = await lookupDns('example.com');
+		expect(facts.a).toEqual(['1.2.3.4', '5.6.7.8']);
+		expect(facts.aaaa).toEqual(['2001:db8::1']);
+		expect(facts.ns).toEqual(['ns1.example.com', 'ns2.example.com']); // 末尾ドット + lowercase
+		expect(facts.mx).toEqual([{ priority: 10, exchange: 'mail.example.com' }]);
+		expect(facts.txt).toEqual(['helloworld']);
+		expect(facts.soa).toBe('ns1.example.com. hostmaster.example.com. 1 7200 3600 1209600 3600');
+		expect(facts.caa).toEqual(['0 issue "letsencrypt.org"']);
+		expect(facts.dnssec_ad).toBe(true);
+	});
+
+	it('falls back to Google when Cloudflare returns Status != 0/3', async () => {
+		setFetch((url) => {
+			if (url.includes('cloudflare-dns.com'))
+				return json({ Status: 2, Answer: [] }); // SERVFAIL
+			// Google
+			const t = Number(new URL(url).searchParams.get('type'));
+			if (t === 1) return json({ Status: 0, AD: false, Answer: [answer(1, '9.9.9.9')] });
+			return json({ Status: 0, AD: false, Answer: [] });
+		});
+		const facts = await lookupDns('example.com');
+		expect(facts.a).toEqual(['9.9.9.9']);
+	});
+
+	it('treats both-resolver failure as empty answer (partial failure)', async () => {
+		setFetch(() => json({ Status: 5, Answer: [] }));
+		const facts = await lookupDns('example.com');
+		expect(facts.a).toEqual([]);
+		expect(facts.dnssec_ad).toBe(false); // status -1 だと AD は集約 false
+	});
+
+	it('treats NXDOMAIN (Status=3) as empty answer (no error)', async () => {
+		setFetch(() => json({ Status: 3, AD: true, Answer: [] }));
+		const facts = await lookupDns('nonexistent.example');
+		expect(facts.a).toEqual([]);
+		expect(facts.ns).toEqual([]);
+		// AD: true で全 type なので集約は true
+		expect(facts.dnssec_ad).toBe(true);
+	});
+
+	it('aggregates AD=false when ANY type lacks AD', async () => {
+		setFetch((url) => {
+			const t = Number(new URL(url).searchParams.get('type'));
+			if (t === 1) return json({ Status: 0, AD: true, Answer: [answer(1, '1.2.3.4')] });
+			// 他の type は AD なし
+			return json({ Status: 0, Answer: [] });
+		});
+		const facts = await lookupDns('example.com');
+		expect(facts.dnssec_ad).toBe(false);
+	});
+
+	it('filters out non-matching answer types (CNAME, etc.)', async () => {
+		setFetch((url) => {
+			const t = Number(new URL(url).searchParams.get('type'));
+			if (t === 1) {
+				return json({
+					Status: 0,
+					AD: true,
+					Answer: [
+						{ type: 5, data: 'cdn.example.com.' }, // CNAME
+						{ type: 1, data: '1.2.3.4' }
+					]
+				});
+			}
+			return json({ Status: 0, AD: true, Answer: [] });
+		});
+		const facts = await lookupDns('example.com');
+		expect(facts.a).toEqual(['1.2.3.4']);
+	});
+
+	it('retries on 429 with Retry-After and eventually succeeds', async () => {
+		vi.useFakeTimers();
+		const counts: Record<number, number> = {};
+		setFetch((url) => {
+			const t = Number(new URL(url).searchParams.get('type'));
+			counts[t] = (counts[t] ?? 0) + 1;
+			if (t === 1 && counts[1] === 1) {
+				return new Response('rate limited', {
+					status: 429,
+					headers: { 'retry-after': '1' }
+				});
+			}
+			return json({ Status: 0, AD: true, Answer: t === 1 ? [answer(1, '1.2.3.4')] : [] });
+		});
+
+		const promise = lookupDns('example.com');
+		// すべての type の retry を消化
+		await vi.advanceTimersByTimeAsync(5000);
+		const facts = await promise;
+		expect(facts.a).toEqual(['1.2.3.4']);
+		expect(counts[1]).toBe(2); // 1 回 retry
+	});
+
+	it('drops malformed answer entries defensively', async () => {
+		setFetch((url) => {
+			const t = Number(new URL(url).searchParams.get('type'));
+			if (t === 1) {
+				return json({
+					Status: 0,
+					AD: true,
+					Answer: [
+						null,
+						{ type: 1 }, // data 欠損
+						{ type: 1, data: 42 }, // data 非 string
+						{ type: 1, data: '1.2.3.4' }
+					]
+				});
+			}
+			return json({ Status: 0, AD: true, Answer: [] });
+		});
+		const facts = await lookupDns('example.com');
+		expect(facts.a).toEqual(['1.2.3.4']);
+	});
+
+	it('returns empty soa when no SOA record', async () => {
+		setFetch(() => json({ Status: 0, AD: true, Answer: [] }));
+		const facts = await lookupDns('example.com');
+		expect(facts.soa).toBeUndefined();
+	});
+});

--- a/scanner/src/doh.ts
+++ b/scanner/src/doh.ts
@@ -1,0 +1,105 @@
+const TYPES = { A: 1, AAAA: 28, NS: 2, MX: 15, TXT: 16, SOA: 6, CAA: 257 } as const;
+
+const CLOUDFLARE = 'https://cloudflare-dns.com/dns-query';
+const GOOGLE = 'https://dns.google/resolve';
+const MAX_RETRY = 2;
+const BACKOFF_MS = [1000, 2000];
+
+interface DohJson {
+	Status: number;
+	AD?: boolean;
+	Answer?: { type: number; data: string }[];
+}
+
+export interface DnsFacts {
+	a: string[];
+	aaaa: string[];
+	ns: string[];
+	mx: { priority: number; exchange: string }[];
+	txt: string[];
+	soa?: string;
+	caa: string[];
+	dnssec_ad: boolean;
+}
+
+async function fetchOne(base: string, name: string, type: number): Promise<DohJson> {
+	const url = `${base}?name=${encodeURIComponent(name)}&type=${type}&do=1&cd=0`;
+	for (let attempt = 0; attempt <= MAX_RETRY; attempt++) {
+		const res = await fetch(url, { headers: { Accept: 'application/dns-json' } });
+		if (res.status === 429 || res.status >= 500) {
+			if (attempt === MAX_RETRY) throw new Error(`doh ${res.status}`);
+			const ra = Number(res.headers.get('retry-after')) * 1000;
+			const wait = Number.isFinite(ra) && ra > 0 ? ra : BACKOFF_MS[attempt];
+			await new Promise((r) => setTimeout(r, wait));
+			continue;
+		}
+		if (!res.ok) throw new Error(`doh ${res.status}`);
+		const json = (await res.json()) as Partial<DohJson>;
+		// 防御 parse: Status は number、Answer は配列、AD は boolean optional
+		const Status = typeof json.Status === 'number' ? json.Status : -1;
+		const Answer = Array.isArray(json.Answer) ? json.Answer : undefined;
+		const AD = typeof json.AD === 'boolean' ? json.AD : undefined;
+		return { Status, Answer, AD };
+	}
+	throw new Error('unreachable');
+}
+
+async function lookupOne(name: string, type: number): Promise<DohJson> {
+	try {
+		const r = await fetchOne(CLOUDFLARE, name, type);
+		if (r.Status === 0 || r.Status === 3) return r; // 0=OK, 3=NXDOMAIN を許容
+		throw new Error(`cf status ${r.Status}`);
+	} catch {
+		try {
+			return await fetchOne(GOOGLE, name, type);
+		} catch {
+			// 両方失敗 → 空 response (partial failure 許容)
+			return { Status: -1, Answer: [], AD: false };
+		}
+	}
+}
+
+export function unquoteTxt(data: string): string {
+	const segs = data.match(/"((?:[^"\\]|\\.)*)"/g);
+	if (!segs) return data;
+	return segs.map((s) => s.slice(1, -1).replace(/\\(.)/g, '$1')).join('');
+}
+
+const stripDot = (s: string) => (s.endsWith('.') ? s.slice(0, -1) : s);
+
+const filterByType = (resp: DohJson, type: number) =>
+	(resp.Answer ?? []).filter(
+		(a): a is { type: number; data: string } =>
+			!!a && a.type === type && typeof a.data === 'string'
+	);
+
+export function parseMx(data: string): { priority: number; exchange: string } | undefined {
+	const m = data.match(/^(\d+)\s+(\S+)$/);
+	if (!m) return undefined;
+	return { priority: Number(m[1]), exchange: stripDot(m[2]).toLowerCase() };
+}
+
+export async function lookupDns(name: string): Promise<DnsFacts> {
+	const [a, aaaa, ns, mx, txt, soa, caa] = await Promise.all([
+		lookupOne(name, TYPES.A),
+		lookupOne(name, TYPES.AAAA),
+		lookupOne(name, TYPES.NS),
+		lookupOne(name, TYPES.MX),
+		lookupOne(name, TYPES.TXT),
+		lookupOne(name, TYPES.SOA),
+		lookupOne(name, TYPES.CAA)
+	]);
+
+	return {
+		a: filterByType(a, TYPES.A).map((r) => r.data),
+		aaaa: filterByType(aaaa, TYPES.AAAA).map((r) => r.data),
+		ns: filterByType(ns, TYPES.NS).map((r) => stripDot(r.data).toLowerCase()),
+		mx: filterByType(mx, TYPES.MX)
+			.map((r) => parseMx(r.data))
+			.filter((x): x is { priority: number; exchange: string } => !!x),
+		txt: filterByType(txt, TYPES.TXT).map((r) => unquoteTxt(r.data)),
+		soa: filterByType(soa, TYPES.SOA)[0]?.data,
+		caa: filterByType(caa, TYPES.CAA).map((r) => r.data),
+		dnssec_ad: [a, aaaa, ns, mx, txt, soa, caa].every((r) => r.AD === true)
+	};
+}

--- a/scanner/src/index.ts
+++ b/scanner/src/index.ts
@@ -1,5 +1,7 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 import type { ScheduledHandler } from 'aws-lambda';
+import { putDns, type DnsRow } from './dns-repo';
+import { lookupDns } from './doh';
 import { listVerifiedDomains, type VerifiedDomain } from './domain-list';
 import { lookupWhois } from './rdap';
 import { putSsl, type SslRow } from './ssl-repo';
@@ -71,6 +73,34 @@ export const handler: ScheduledHandler = async (event) => {
 					error: msg
 				};
 				await putSsl(d.userId, d.hostname, errorRow).catch(() => {});
+			}
+
+			// DNS (RDAP / TLS とは独立した try/catch)
+			const dnsAt = Math.floor(Date.now() / 1000);
+			try {
+				const facts = await lookupDns(d.hostname);
+				const row: DnsRow = { ...facts, updated_at: dnsAt };
+				await putDns(d.userId, d.hostname, row);
+				logger.info('dns_ok', {
+					host: d.hostname,
+					dnssec: facts.dnssec_ad,
+					a_count: facts.a.length
+				});
+			} catch (err) {
+				const msg = (err as Error).message ?? 'unknown';
+				logger.warn('dns_failed', { host: d.hostname, msg });
+				const errorRow: DnsRow = {
+					a: [],
+					aaaa: [],
+					ns: [],
+					mx: [],
+					txt: [],
+					caa: [],
+					dnssec_ad: false,
+					updated_at: dnsAt,
+					error: msg
+				};
+				await putDns(d.userId, d.hostname, errorRow).catch(() => {});
 			}
 		}
 	};


### PR DESCRIPTION
## Summary

scanner Lambda 3 つ目の scanner。Lambda 環境で安定する HTTPS 443 経由の DoH (DNS over HTTPS) で 7 種類の record (A / AAAA / NS / MX / TXT / SOA / CAA) を取得し、\`DOMAIN#<host>#DNS\` sub-row に書き込む。

これで Phase 1 の scan 機能は揃い (RDAP + TLS + DNS の 3 つ)、残りは EventBridge Scheduler 連携 (#18) と SES alert (#19)。

## 実装

### 新規 helpers
- \`scanner/src/doh.ts\` — \`lookupDns(name)\` で 7 type を Promise.all、Cloudflare→Google fallback、DNSSEC do=1&cd=0 で AD 取得 + AND 集約、両 resolver 失敗時は空 response (partial failure 許容)、防御 parse (\`Status\`/\`Answer\`/\`AD\` は typeof check)、429/5xx で Retry-After + 指数バックオフ max 2 retry。各 type parser (\`unquoteTxt\`, \`parseMx\`, \`stripDot\`)
- \`scanner/src/dns-repo.ts\` — \`putDns\` / \`getDns\` で \`DOMAIN#<host>#DNS\` sub-row I/O (whois-repo / ssl-repo と同型)

### 既存 handler への統合 (\`scanner/src/index.ts\`)
- worker 内 TLS の後ろに **独立 try/catch で DNS ブロック**追加
- 並列度 5 維持
- 1 ドメインで RDAP + TLS + DNS の 3 scanner が直列実行 (各々独立)

### Tests (vitest 2 本、計 17 ケース)
- \`doh.test.ts\` (\`globalThis.fetch = vi.fn()\` で stub):
  - 各 type parse (A/AAAA/NS/MX/TXT/SOA/CAA、NS は末尾ドット + lowercase、MX は priority/exchange 分解)
  - Cloudflare → Google fallback (Status≠0/3 で切替)
  - 両 resolver 失敗 → 空 response (partial failure)
  - NXDOMAIN (Status=3) → 空配列扱い、error にしない
  - DNSSEC AD AND 集約 (1 つでも false なら全体 false)
  - 429 + Retry-After 1 → 200 で retry 成功 (\`vi.useFakeTimers\`)
  - filterByType で CNAME (type=5) 除外
  - malformed answer 防御 parse (null/data 欠損/data 非 string)
  - SOA なし → undefined
- \`dns-repo.test.ts\` (DDB Local 前提): round trip + undefined 属性省略 + 上書き

## DnsFacts 設計

master plan の \`records=[{type, value}]\` ではなく **record type 別 attribute** を採用 (型安全 + UI で section 表示しやすい):

\`\`\`ts
interface DnsFacts {
	a: string[];
	aaaa: string[];
	ns: string[];                                       // 末尾ドット除去 + lowercase
	mx: { priority: number; exchange: string }[];
	txt: string[];                                      // unquoteTxt 適用済み
	soa?: string;                                       // 1 つだけ、生 data 文字列
	caa: string[];                                      // 生 data 文字列 (parse 複雑なので保留)
	dnssec_ad: boolean;
}
\`\`\`

CAA/SOA は parse 複雑なので生 data 文字列で保存 (parse は #20 ダッシュボードで必要なら実施)。

## 動作確認 (実施済み)

- [x] \`pnpm -C scanner typecheck\` 0 エラー
- [x] \`pnpm -C scanner test\` **47/47 pass** (新規 17 + 既存 30)
- [x] DDB Local + 手動 invoke で実 DoH に投げて確認:
  - \`cloudflare.com\`: a 2 / ns 5 / mx 4 / soa / caa 11 / dnssec_ad=true
  - \`example.com\`: a 2 / aaaa 2 / ns 2 (cloudflare) / dnssec_ad=true
  - rdap_ok / tls_ok / dns_ok の 3 scanner 全部成功

## 設計判断

- **wrapper 重複は許容**: web 側 \`web/src/lib/server/doh.ts\` (TXT のみ、Issue #14) はそのまま、scanner 側は別ファイルで 7 type に拡張
- **CI で実 DoH は叩かない**: parser テストでカバー (RDAP/TLS と同方針)
- **DNSSEC AD AND 集約**: 厳しめの判定。Cloudflare/Google でブレが目立てば primary のみ判定に緩める余地
- **CNAME chain は捨てる**: A/AAAA Answer に CNAME (type=5) が混じるが filterByType で type=1/28 のみ抽出

## 残タスク (この PR では対応しない)

- EventBridge Scheduler 連携 (Terraform、日 1 回起動) は **#18**
- SES アラートメール (期限近接通知、SSL 切れ、DNS 変更検知) は **#19**
- ダッシュボード UI 仕上げは **#20**
- \`docs/design/04-scanners.md\` 更新は **#29**

## Closes

Closes #17