### PR TITLE
infra: scanner lambda + ecr + eventbridge scheduler (fixes #18)

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,0 +1,48 @@
+resource "aws_ecr_repository" "scanner" {
+  name                 = "${var.project}-scanner"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true # tfstate 紛失時の手動 cleanup を可能にする
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "scanner" {
+  repository = aws_ecr_repository.scanner.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 5 tagged images"
+        selection = {
+          tagStatus      = "tagged"
+          tagPatternList = ["*"]
+          countType      = "imageCountMoreThan"
+          countNumber    = 5
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Expire untagged images after 7 days"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 7
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/infra/eventbridge.tf
+++ b/infra/eventbridge.tf
@@ -1,0 +1,27 @@
+resource "aws_scheduler_schedule" "scanner_daily" {
+  name = "${var.project}-scanner-daily"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression          = "cron(0 3 * * ? *)" # 毎日 03:00 JST
+  schedule_expression_timezone = "Asia/Tokyo"
+
+  target {
+    arn      = aws_lambda_function.scanner.arn
+    role_arn = aws_iam_role.scanner_scheduler.arn
+
+    retry_policy {
+      maximum_event_age_in_seconds = 3600 # 1h を超えたら諦め
+      maximum_retry_attempts       = 3
+    }
+
+    dead_letter_config {
+      arn = aws_sqs_queue.scanner_dlq.arn
+    }
+
+    # scanner handler は event を見ないが空 JSON を渡す
+    input = jsonencode({})
+  }
+}

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,0 +1,90 @@
+# --- scanner Lambda role -------------------------------------------------
+
+resource "aws_iam_role" "scanner_lambda" {
+  name = "${var.project}-scanner"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = {
+    Project = var.project
+  }
+}
+
+# Logs (basic execution)
+resource "aws_iam_role_policy_attachment" "scanner_basic" {
+  role       = aws_iam_role.scanner_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# DynamoDB single-table アクセス
+resource "aws_iam_role_policy" "scanner_dynamodb" {
+  name = "${var.project}-scanner-dynamodb"
+  role = aws_iam_role.scanner_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:Scan",
+        "dynamodb:Query"
+      ]
+      Resource = [aws_dynamodb_table.vigil.arn]
+    }]
+  })
+}
+
+# SES 送信権限は #19 で追加 (今回 scope 外)
+
+# --- EventBridge Scheduler role (Lambda invoke 用) -----------------------
+
+resource "aws_iam_role" "scanner_scheduler" {
+  name = "${var.project}-scanner-scheduler"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "scheduler.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_iam_role_policy" "scanner_scheduler_invoke" {
+  name = "${var.project}-scanner-scheduler-invoke"
+  role = aws_iam_role.scanner_scheduler.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "lambda:InvokeFunction"
+        Resource = [
+          aws_lambda_function.scanner.arn,
+          "${aws_lambda_function.scanner.arn}:*"
+        ]
+      },
+      {
+        Effect   = "Allow"
+        Action   = "sqs:SendMessage"
+        Resource = [aws_sqs_queue.scanner_dlq.arn]
+      }
+    ]
+  })
+}

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -1,0 +1,40 @@
+# Lambda 自動作成より先に log group を作って retention 14d を強制
+# (Lambda 自動生成の log group は無期限保持で課金事故になるため)
+resource "aws_cloudwatch_log_group" "scanner" {
+  name              = "/aws/lambda/${var.project}-scanner"
+  retention_in_days = 14
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_lambda_function" "scanner" {
+  function_name = "${var.project}-scanner"
+  role          = aws_iam_role.scanner_lambda.arn
+
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.scanner.repository_url}:placeholder"
+  architectures = ["arm64"]
+
+  memory_size = 512
+  timeout     = 60 # 100 ドメイン × ~0.4s / 5 並列 ≈ 8s + 余裕
+
+  environment {
+    variables = {
+      VIGIL_TABLE_NAME = aws_dynamodb_table.vigil.name
+      LOG_LEVEL        = "INFO"
+    }
+  }
+
+  lifecycle {
+    # CI/CD (#23) で push される実 image を Terraform 側で上書きしない
+    ignore_changes = [image_uri]
+  }
+
+  depends_on = [aws_cloudwatch_log_group.scanner]
+
+  tags = {
+    Project = var.project
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -17,3 +17,23 @@ output "dynamodb_table_arn" {
   description = "ARN of the vigil DynamoDB table (used for Lambda IAM policy Resource)"
   value       = aws_dynamodb_table.vigil.arn
 }
+
+output "scanner_function_name" {
+  description = "Lambda function name for the scanner (used by CI/CD to update image)"
+  value       = aws_lambda_function.scanner.function_name
+}
+
+output "scanner_function_arn" {
+  description = "Lambda function ARN for the scanner"
+  value       = aws_lambda_function.scanner.arn
+}
+
+output "scanner_ecr_repository_url" {
+  description = "ECR repository URL for scanner container image"
+  value       = aws_ecr_repository.scanner.repository_url
+}
+
+output "scanner_dlq_arn" {
+  description = "SQS DLQ ARN for scanner schedule failures"
+  value       = aws_sqs_queue.scanner_dlq.arn
+}

--- a/infra/sqs.tf
+++ b/infra/sqs.tf
@@ -1,0 +1,31 @@
+resource "aws_sqs_queue" "scanner_dlq" {
+  name                       = "${var.project}-scanner-dlq"
+  message_retention_seconds  = 1209600 # 14 days
+  visibility_timeout_seconds = 60
+
+  tags = {
+    Project = var.project
+  }
+}
+
+# DLQ にメッセージが 1 件でも積まれたら alarm 発火。
+# alarm_actions は #19 で SNS → SES 連携を追加する時に設定 (今回は alarm 単体)。
+resource "aws_cloudwatch_metric_alarm" "scanner_dlq_not_empty" {
+  alarm_name          = "${var.project}-scanner-dlq-not-empty"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    QueueName = aws_sqs_queue.scanner_dlq.name
+  }
+
+  tags = {
+    Project = var.project
+  }
+}


### PR DESCRIPTION
## Summary

scanner Lambda を毎日 03:00 JST に起動する仕組みを Terraform で定義。AWS 側に **scanner Lambda + ECR + EventBridge Scheduler + DLQ + IAM** 一式を作る。scope を scanner 単独に絞り (web は #21、Powertools/SSM 配線は #22、CI/CD は #23、本番初 apply は #25)、infra-only の小さい PR にした。

実 \`terraform apply\` は **#25 (本番デプロイ + 疎通確認) で扱う**。Issue #18 の DoD は「Terraform リソース定義 + \`terraform fmt + validate\` 通る」まで。

## 実装

### 新規 ファイル
- \`infra/ecr.tf\` — scanner ECR repo + lifecycle policy (タグ付き最新 5 個保持、タグ無し 7 日で expire)
- \`infra/iam.tf\` — scanner Lambda role (DynamoDB single-table アクセス + Logs basic execution) + Scheduler role (lambda:InvokeFunction + sqs:SendMessage to DLQ)
- \`infra/lambda.tf\` — scanner Lambda (container image、placeholder image_uri、arm64、512MB / 60s、env: \`VIGIL_TABLE_NAME\` + \`LOG_LEVEL=INFO\`、\`lifecycle ignore_changes = [image_uri]\` で CI/CD 上書き許容)。CloudWatch log group を **先に作成**して \`retention_in_days = 14\` 強制 (Lambda 自動生成だと無期限保持で課金事故)
- \`infra/sqs.tf\` — scanner DLQ (14d retention) + CloudWatch alarm (DLQ メッセージ数 > 0)。\`alarm_actions\` は #19 で SES 連携時に追加
- \`infra/eventbridge.tf\` — \`aws_scheduler_schedule\` で毎日 03:00 JST、target = scanner Lambda、\`retry_policy\` (max 3 / max age 1h)、\`dead_letter_config\` で DLQ 連携、\`flexible_time_window { mode = "OFF" }\`

### 編集
- \`infra/outputs.tf\` — \`scanner_function_name\` / \`scanner_function_arn\` / \`scanner_ecr_repository_url\` / \`scanner_dlq_arn\` を追加 (CI/CD で参照)

## 動作確認 (実施済み)

- [x] \`flox activate -- terraform -chdir=infra fmt -check\` 差分なし
- [x] \`flox activate -- terraform -chdir=infra init -backend=false\` 成功
- [x] \`flox activate -- terraform -chdir=infra validate\` 成功 (既知の \`aws_dynamodb_table.hash_key\` deprecation 警告のみ、新規リソースに新たな警告なし)

実 \`plan -refresh=false\` は S3 backend init + AWS credentials が必要なので **#25 で扱う**。

## 設計判断

- **scanner 単独 PR**: 依存関係最小 (web Lambda + CloudFront 不要)、PR が ~500 行に収まる、段階的に動作確認可能。Terraform は宣言的なので #21/#22 で後付け OK
- **CloudWatch log group を Terraform で先に作成**: Lambda 自動作成だと無期限保持 = 課金事故リスク。retention 14d を強制
- **DLQ は EventBridge Scheduler 側**: Scheduler が Lambda 起動に失敗した時用。Lambda 内部の async invoke DLQ とは別物
- **\`lifecycle ignore_changes = [image_uri]\`**: CI/CD (#23) で git SHA タグの image を push する想定。Terraform 側で placeholder タグに戻さないため
- **placeholder image 問題**: ECR 空 → Lambda apply 失敗。#25 で \`terraform apply -target=aws_ecr_repository.scanner\` → CI/CD で初回 push → 全体 \`apply\`、の順序を README に追記予定

## 残タスク (この PR では対応しない)

- web Lambda + CloudFront + Function URL OAC + Route53 + ACM は **#21**
- Powertools layer + SSM Parameter Store + Secrets Extension 配線は **#22**
- CI/CD (OIDC + paths-filter + ECR push + Lambda update) は **#23**
- SES アラートメール (DLQ alarm 通知含む) は **#19**
- 本番初 apply + 疎通確認 (\`aws scheduler invoke-schedule\` 等) は **#25**
- \`docs/design/06-infra.md\` 更新は **#29**

## Closes

Closes #18