### PR TITLE
feat: ses alert email with dedup + dry-run (fixes #19)

### DIFF
--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -44,7 +44,25 @@ resource "aws_iam_role_policy" "scanner_dynamodb" {
   })
 }
 
-# SES 送信権限は #19 で追加 (今回 scope 外)
+# SES 送信権限 (#19): SES_SENDER 一致時のみ許可
+resource "aws_iam_role_policy" "scanner_ses" {
+  name = "${var.project}-scanner-ses"
+  role = aws_iam_role.scanner_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ses:SendEmail", "ses:SendRawEmail"]
+      Resource = [aws_ses_domain_identity.vigil.arn]
+      Condition = {
+        StringEquals = {
+          "ses:FromAddress" = var.alert_sender
+        }
+      }
+    }]
+  })
+}
 
 # --- EventBridge Scheduler role (Lambda invoke 用) -----------------------
 

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -24,6 +24,9 @@ resource "aws_lambda_function" "scanner" {
     variables = {
       VIGIL_TABLE_NAME = aws_dynamodb_table.vigil.name
       LOG_LEVEL        = "INFO"
+      SES_SENDER       = var.alert_sender
+      SES_REGION       = var.region
+      SES_DRY_RUN      = "true" # 検証完了後 #25 で false に切替
     }
   }
 

--- a/infra/ses.tf
+++ b/infra/ses.tf
@@ -1,0 +1,46 @@
+data "aws_route53_zone" "root" {
+  name         = "tommykeyapp.com."
+  private_zone = false
+}
+
+resource "aws_ses_domain_identity" "vigil" {
+  domain = var.domain # vigil.tommykeyapp.com
+}
+
+resource "aws_ses_domain_dkim" "vigil" {
+  domain = aws_ses_domain_identity.vigil.domain
+}
+
+# Easy DKIM CNAME 3 本
+resource "aws_route53_record" "dkim" {
+  count   = 3
+  zone_id = data.aws_route53_zone.root.zone_id
+  name    = "${aws_ses_domain_dkim.vigil.dkim_tokens[count.index]}._domainkey.${var.domain}"
+  type    = "CNAME"
+  ttl     = 600
+  records = ["${aws_ses_domain_dkim.vigil.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}
+
+# SPF (subdomain 専用 TXT、root の SPF とは独立)
+resource "aws_route53_record" "spf" {
+  zone_id = data.aws_route53_zone.root.zone_id
+  name    = var.domain
+  type    = "TXT"
+  ttl     = 600
+  records = ["v=spf1 include:amazonses.com -all"]
+}
+
+# DMARC
+resource "aws_route53_record" "dmarc" {
+  zone_id = data.aws_route53_zone.root.zone_id
+  name    = "_dmarc.${var.domain}"
+  type    = "TXT"
+  ttl     = 600
+  records = ["v=DMARC1; p=quarantine; rua=mailto:dmarc@tommykeyapp.com; fo=1"]
+}
+
+# DKIM CNAME 反映後に SES の verification 完了を待つ (apply 中ブロック)
+resource "aws_ses_domain_identity_verification" "vigil" {
+  domain     = aws_ses_domain_identity.vigil.id
+  depends_on = [aws_route53_record.dkim, aws_route53_record.spf]
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -15,3 +15,9 @@ variable "domain" {
   type        = string
   default     = "vigil.tommykeyapp.com"
 }
+
+variable "alert_sender" {
+  description = "SES sender address for vigil alert emails (must match a verified domain identity)"
+  type        = string
+  default     = "notifications@vigil.tommykeyapp.com"
+}

--- a/scanner/src/alert-repo.test.ts
+++ b/scanner/src/alert-repo.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getAlert, putAlert } from './alert-repo';
+
+const SKIP = !process.env.AWS_ENDPOINT_URL;
+
+describe.skipIf(SKIP)('alert-repo (DynamoDB Local)', () => {
+	const userId = `alert-test-${Date.now()}`;
+
+	it('round trip: putAlert → getAlert', async () => {
+		const hostname = `t1-${Date.now()}.example.com`;
+		await putAlert(userId, hostname, 'WHOIS_7D', { last_target: '1900000000', last_sent_at: 100 });
+		const got = await getAlert(userId, hostname, 'WHOIS_7D');
+		expect(got?.last_target).toBe('1900000000');
+		expect(got?.last_sent_at).toBe(100);
+	});
+
+	it('returns undefined when row not present', async () => {
+		const hostname = `t2-${Date.now()}.example.com`;
+		expect(await getAlert(userId, hostname, 'SSL_30D')).toBeUndefined();
+	});
+
+	it('overwrites earlier row on second putAlert', async () => {
+		const hostname = `t3-${Date.now()}.example.com`;
+		await putAlert(userId, hostname, 'DNS_NS_CHANGED', { last_target: 'old', last_sent_at: 0 });
+		await putAlert(userId, hostname, 'DNS_NS_CHANGED', { last_target: 'new', last_sent_at: 200 });
+		const got = await getAlert(userId, hostname, 'DNS_NS_CHANGED');
+		expect(got?.last_target).toBe('new');
+		expect(got?.last_sent_at).toBe(200);
+	});
+});

--- a/scanner/src/alert-repo.ts
+++ b/scanner/src/alert-repo.ts
@@ -1,0 +1,22 @@
+import { getItem, putItem } from './ddb';
+import type { AlertKind } from './alert';
+
+export interface AlertRow {
+	last_sent_at: number; // epoch sec (baseline 保存時は 0)
+	last_target: string;
+}
+
+const userPk = (uid: string) => `USER#${uid}`;
+const alertSk = (host: string, kind: AlertKind) => `DOMAIN#${host}#ALERT#${kind}`;
+
+export const putAlert = (uid: string, host: string, kind: AlertKind, row: AlertRow) =>
+	putItem({ Item: { pk: userPk(uid), sk: alertSk(host, kind), ...row } });
+
+export async function getAlert(
+	uid: string,
+	host: string,
+	kind: AlertKind
+): Promise<AlertRow | undefined> {
+	const r = await getItem({ Key: { pk: userPk(uid), sk: alertSk(host, kind) } });
+	return r.Item as AlertRow | undefined;
+}

--- a/scanner/src/alert.test.ts
+++ b/scanner/src/alert.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSend = vi.fn();
+vi.mock('@aws-sdk/client-ses', () => {
+	class SESClient {
+		send = mockSend;
+	}
+	class SendEmailCommand {
+		constructor(public input: unknown) {}
+	}
+	return { SESClient, SendEmailCommand };
+});
+
+const mockGetAlert = vi.fn();
+const mockPutAlert = vi.fn();
+vi.mock('./alert-repo', () => ({
+	getAlert: (...args: unknown[]) => mockGetAlert(...args),
+	putAlert: (...args: unknown[]) => mockPutAlert(...args)
+}));
+
+import { _resetSesClientForTests, evaluateAndSendAlerts, renderEmail } from './alert';
+import type { DnsRow } from './dns-repo';
+import type { SslRow } from './ssl-repo';
+import type { WhoisRow } from './whois-repo';
+
+const NOW_SEC = 1_800_000_000;
+const DAY = 86_400;
+
+const ctx = { userId: 'u1', hostname: 'example.com', email: 'me@example.com' };
+
+beforeEach(() => {
+	mockSend.mockReset();
+	mockSend.mockResolvedValue({ MessageId: 'fake' });
+	mockGetAlert.mockReset();
+	mockGetAlert.mockResolvedValue(undefined);
+	mockPutAlert.mockReset();
+	mockPutAlert.mockResolvedValue(undefined);
+	_resetSesClientForTests();
+	process.env.SES_DRY_RUN = 'false';
+	process.env.SES_SENDER = 'notifications@vigil.tommykeyapp.com';
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(NOW_SEC * 1000));
+});
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+const buildWhois = (expires_at: number | undefined): WhoisRow => ({
+	registrar: 'TestReg',
+	expires_at,
+	nameservers: [],
+	statuses: [],
+	redacted: false,
+	updated_at: NOW_SEC
+});
+
+const buildSsl = (overrides: Partial<SslRow> = {}): SslRow => ({
+	issuer: 'Test CA',
+	subject: 'example.com',
+	san: ['example.com'],
+	valid_to: NOW_SEC + 20 * DAY,
+	authorized: true,
+	updated_at: NOW_SEC,
+	...overrides
+});
+
+const buildDns = (ns: string[]): DnsRow => ({
+	a: ['1.2.3.4'],
+	aaaa: [],
+	ns,
+	mx: [],
+	txt: [],
+	caa: [],
+	dnssec_ad: true,
+	updated_at: NOW_SEC
+});
+
+describe('evaluateAndSendAlerts — WHOIS window', () => {
+	it.each([
+		[5 * DAY, 'WHOIS_7D'],
+		[20 * DAY, 'WHOIS_30D'],
+		[12 * 3600, 'WHOIS_1D']
+	] as const)('expires in %s sec → kind %s', async (offsetSec, expectedKind) => {
+		await evaluateAndSendAlerts(ctx, buildWhois(NOW_SEC + offsetSec), undefined, undefined);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+		expect(mockPutAlert).toHaveBeenCalledWith('u1', 'example.com', expectedKind, expect.anything());
+	});
+
+	it('does not fire when expires > 30 days', async () => {
+		await evaluateAndSendAlerts(ctx, buildWhois(NOW_SEC + 60 * DAY), undefined, undefined);
+		expect(mockSend).not.toHaveBeenCalled();
+		expect(mockPutAlert).not.toHaveBeenCalled();
+	});
+
+	it('does not fire when expires_at missing', async () => {
+		await evaluateAndSendAlerts(ctx, buildWhois(undefined), undefined, undefined);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+});
+
+describe('evaluateAndSendAlerts — SSL', () => {
+	it('fires SSL_30D for valid cert in 20 days', async () => {
+		await evaluateAndSendAlerts(ctx, undefined, buildSsl({ valid_to: NOW_SEC + 20 * DAY }), undefined);
+		expect(mockPutAlert).toHaveBeenCalledWith('u1', 'example.com', 'SSL_30D', expect.anything());
+	});
+
+	it('fires SSL_EXPIRED when authorized=false', async () => {
+		await evaluateAndSendAlerts(
+			ctx,
+			undefined,
+			buildSsl({ authorized: false, authorization_error: 'CERT_HAS_EXPIRED' }),
+			undefined
+		);
+		expect(mockPutAlert).toHaveBeenCalledWith('u1', 'example.com', 'SSL_EXPIRED', expect.anything());
+	});
+});
+
+describe('evaluateAndSendAlerts — DNS NS_CHANGED', () => {
+	it('first observation: baseline saved (no email)', async () => {
+		mockGetAlert.mockResolvedValue(undefined);
+		await evaluateAndSendAlerts(ctx, undefined, undefined, buildDns(['ns1.x', 'ns2.x']));
+		expect(mockSend).not.toHaveBeenCalled();
+		expect(mockPutAlert).toHaveBeenCalledWith(
+			'u1',
+			'example.com',
+			'DNS_NS_CHANGED',
+			expect.objectContaining({ last_sent_at: 0 })
+		);
+	});
+
+	it('subsequent change: send email', async () => {
+		mockGetAlert.mockResolvedValue({ last_target: 'old.x,old2.x', last_sent_at: 100 });
+		await evaluateAndSendAlerts(ctx, undefined, undefined, buildDns(['new1.x', 'new2.x']));
+		expect(mockSend).toHaveBeenCalledTimes(1);
+		expect(mockPutAlert).toHaveBeenCalledWith(
+			'u1',
+			'example.com',
+			'DNS_NS_CHANGED',
+			expect.objectContaining({ last_target: 'new1.x,new2.x' })
+		);
+	});
+
+	it('same NS as last time: skip', async () => {
+		mockGetAlert.mockResolvedValue({ last_target: 'ns1.x,ns2.x', last_sent_at: 100 });
+		await evaluateAndSendAlerts(ctx, undefined, undefined, buildDns(['ns2.x', 'ns1.x']));
+		expect(mockSend).not.toHaveBeenCalled();
+		expect(mockPutAlert).not.toHaveBeenCalled();
+	});
+});
+
+describe('dedup', () => {
+	it('skip when prev.last_target equals current target', async () => {
+		const expires = NOW_SEC + 5 * DAY;
+		mockGetAlert.mockResolvedValue({ last_target: String(expires), last_sent_at: 100 });
+		await evaluateAndSendAlerts(ctx, buildWhois(expires), undefined, undefined);
+		expect(mockSend).not.toHaveBeenCalled();
+		expect(mockPutAlert).not.toHaveBeenCalled();
+	});
+
+	it('send when target differs (e.g. domain renewed → new expires_at)', async () => {
+		mockGetAlert.mockResolvedValue({ last_target: '999', last_sent_at: 100 });
+		await evaluateAndSendAlerts(ctx, buildWhois(NOW_SEC + 5 * DAY), undefined, undefined);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('dry-run', () => {
+	it('does not invoke SES when SES_DRY_RUN=true', async () => {
+		process.env.SES_DRY_RUN = 'true';
+		await evaluateAndSendAlerts(ctx, buildWhois(NOW_SEC + 5 * DAY), undefined, undefined);
+		expect(mockSend).not.toHaveBeenCalled();
+		expect(mockPutAlert).toHaveBeenCalledTimes(1); // dedup record は更新する
+	});
+
+	it('does not invoke SES when SES_SENDER is unset', async () => {
+		process.env.SES_SENDER = '';
+		await evaluateAndSendAlerts(ctx, buildWhois(NOW_SEC + 5 * DAY), undefined, undefined);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+});
+
+describe('renderEmail', () => {
+	it('produces non-empty subject + body for each kind', () => {
+		const w = buildWhois(NOW_SEC + 5 * DAY);
+		const s = buildSsl();
+		const d = buildDns(['ns1.x']);
+		const kinds = [
+			'WHOIS_30D',
+			'WHOIS_7D',
+			'WHOIS_1D',
+			'SSL_30D',
+			'SSL_7D',
+			'SSL_1D',
+			'SSL_EXPIRED',
+			'DNS_NS_CHANGED'
+		] as const;
+		for (const kind of kinds) {
+			const { subject, body } = renderEmail(kind, 'example.com', w, s, d);
+			expect(subject).toContain('example.com');
+			expect(body.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/scanner/src/alert.ts
+++ b/scanner/src/alert.ts
@@ -1,0 +1,198 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
+import { getAlert, putAlert } from './alert-repo';
+import type { DnsRow } from './dns-repo';
+import type { SslRow } from './ssl-repo';
+import type { WhoisRow } from './whois-repo';
+
+export type AlertKind =
+	| 'WHOIS_30D'
+	| 'WHOIS_7D'
+	| 'WHOIS_1D'
+	| 'SSL_30D'
+	| 'SSL_7D'
+	| 'SSL_1D'
+	| 'SSL_EXPIRED'
+	| 'DNS_NS_CHANGED';
+
+const SEC_PER_DAY = 86_400;
+
+const logger = new Logger({ serviceName: 'vigil-alert' });
+
+let cachedSes: SESClient | undefined;
+function getSesClient(): SESClient {
+	if (cachedSes) return cachedSes;
+	cachedSes = new SESClient({ region: process.env.SES_REGION ?? 'ap-northeast-1' });
+	return cachedSes;
+}
+
+export interface AlertCtx {
+	userId: string;
+	hostname: string;
+	email: string;
+}
+
+interface Candidate {
+	kind: AlertKind;
+	target: string;
+}
+
+// 注意: WhoisFacts.expires_at / SslFacts.valid_to は **epoch sec の number**
+function evalWhois(nowSec: number, whois?: WhoisRow): Candidate | null {
+	if (!whois || typeof whois.expires_at !== 'number') return null;
+	const days = Math.ceil((whois.expires_at - nowSec) / SEC_PER_DAY);
+	const target = String(whois.expires_at);
+	if (days >= 0 && days <= 1) return { kind: 'WHOIS_1D', target };
+	if (days > 1 && days <= 7) return { kind: 'WHOIS_7D', target };
+	if (days > 7 && days <= 30) return { kind: 'WHOIS_30D', target };
+	return null;
+}
+
+function evalSsl(nowSec: number, ssl?: SslRow): Candidate | null {
+	if (!ssl) return null;
+	if (!ssl.authorized || ssl.authorization_error === 'CERT_HAS_EXPIRED') {
+		return { kind: 'SSL_EXPIRED', target: String(ssl.valid_to ?? 'unknown') };
+	}
+	if (typeof ssl.valid_to !== 'number') return null;
+	const days = Math.ceil((ssl.valid_to - nowSec) / SEC_PER_DAY);
+	const target = String(ssl.valid_to);
+	if (days >= 0 && days <= 1) return { kind: 'SSL_1D', target };
+	if (days > 1 && days <= 7) return { kind: 'SSL_7D', target };
+	if (days > 7 && days <= 30) return { kind: 'SSL_30D', target };
+	return null;
+}
+
+function evalNs(dns?: DnsRow): Candidate | null {
+	if (!dns?.ns?.length) return null;
+	return { kind: 'DNS_NS_CHANGED', target: [...dns.ns].sort().join(',') };
+}
+
+function fmtIso(epochSec: number): string {
+	return new Date(epochSec * 1000).toISOString();
+}
+
+export function renderEmail(
+	kind: AlertKind,
+	host: string,
+	w?: WhoisRow,
+	s?: SslRow,
+	d?: DnsRow
+): { subject: string; body: string } {
+	switch (kind) {
+		case 'WHOIS_30D':
+		case 'WHOIS_7D':
+		case 'WHOIS_1D': {
+			const days = kind === 'WHOIS_30D' ? 30 : kind === 'WHOIS_7D' ? 7 : 1;
+			const exp = w?.expires_at ? fmtIso(w.expires_at) : '不明';
+			return {
+				subject: `[vigil] ${host} — ドメイン期限が ${days} 日以内に切れます`,
+				body:
+					`vigil が監視中の ${host} の WHOIS 期限が ${days} 日以内に切れます。\n\n` +
+					`登録 registrar: ${w?.registrar ?? '不明'}\n` +
+					`期限: ${exp}\n` +
+					`status: ${(w?.statuses ?? []).join(', ') || '(なし)'}\n\n` +
+					`更新を忘れずに行ってください。`
+			};
+		}
+		case 'SSL_30D':
+		case 'SSL_7D':
+		case 'SSL_1D': {
+			const days = kind === 'SSL_30D' ? 30 : kind === 'SSL_7D' ? 7 : 1;
+			const exp = s?.valid_to ? fmtIso(s.valid_to) : '不明';
+			return {
+				subject: `[vigil] ${host} — TLS 証明書期限が ${days} 日以内に切れます`,
+				body:
+					`vigil が監視中の ${host} の TLS 証明書期限が ${days} 日以内に切れます。\n\n` +
+					`発行者: ${s?.issuer ?? '不明'}\n` +
+					`期限: ${exp}\n` +
+					`SAN: ${(s?.san ?? []).join(', ') || '(なし)'}\n\n` +
+					`更新を忘れずに行ってください。`
+			};
+		}
+		case 'SSL_EXPIRED': {
+			const exp = s?.valid_to ? fmtIso(s.valid_to) : '不明';
+			return {
+				subject: `[vigil] ${host} — TLS 証明書が無効です`,
+				body:
+					`vigil が監視中の ${host} の TLS 証明書が無効です。\n\n` +
+					`認証エラー: ${s?.authorization_error ?? '不明'}\n` +
+					`発行者: ${s?.issuer ?? '不明'}\n` +
+					`期限: ${exp}\n\n` +
+					`証明書を確認・更新してください。`
+			};
+		}
+		case 'DNS_NS_CHANGED':
+			return {
+				subject: `[vigil] ${host} — NS レコードが変更されました`,
+				body:
+					`vigil が監視中の ${host} の NS レコードが変更されました。\n\n` +
+					`現在の NS: ${(d?.ns ?? []).join(', ') || '(なし)'}\n\n` +
+					`意図した変更でない場合は乗っ取りや誤操作の可能性があります。`
+			};
+	}
+}
+
+async function sendOrLog(ctx: AlertCtx, kind: AlertKind, subject: string, body: string) {
+	const dryRun = process.env.SES_DRY_RUN === 'true';
+	const sender = process.env.SES_SENDER ?? '';
+	if (dryRun || !sender) {
+		logger.info('alert_dry_run', { to: ctx.email, kind, host: ctx.hostname, subject });
+		return;
+	}
+	await getSesClient().send(
+		new SendEmailCommand({
+			Source: sender,
+			Destination: { ToAddresses: [ctx.email] },
+			Message: {
+				Subject: { Data: subject, Charset: 'UTF-8' },
+				Body: { Text: { Data: body, Charset: 'UTF-8' } }
+			}
+		})
+	);
+	logger.info('alert_sent', { host: ctx.hostname, kind });
+}
+
+export async function evaluateAndSendAlerts(
+	ctx: AlertCtx,
+	whois?: WhoisRow,
+	ssl?: SslRow,
+	dns?: DnsRow
+): Promise<void> {
+	const nowSec = Math.floor(Date.now() / 1000);
+	const candidates: Candidate[] = [];
+	const w = evalWhois(nowSec, whois);
+	if (w) candidates.push(w);
+	const s = evalSsl(nowSec, ssl);
+	if (s) candidates.push(s);
+	const n = evalNs(dns);
+	if (n) candidates.push(n);
+
+	for (const { kind, target } of candidates) {
+		const prev = await getAlert(ctx.userId, ctx.hostname, kind);
+
+		if (prev?.last_target === target) {
+			logger.debug('alert_dedup_skip', { host: ctx.hostname, kind });
+			continue;
+		}
+
+		// NS の初回は baseline 保存のみ (送信抑止)
+		if (kind === 'DNS_NS_CHANGED' && !prev) {
+			await putAlert(ctx.userId, ctx.hostname, kind, { last_target: target, last_sent_at: 0 });
+			logger.info('alert_baseline', { host: ctx.hostname, kind });
+			continue;
+		}
+
+		const { subject, body } = renderEmail(kind, ctx.hostname, whois, ssl, dns);
+		await sendOrLog(ctx, kind, subject, body);
+
+		await putAlert(ctx.userId, ctx.hostname, kind, {
+			last_target: target,
+			last_sent_at: nowSec
+		});
+	}
+}
+
+// テスト用: SES client cache をリセット
+export function _resetSesClientForTests() {
+	cachedSes = undefined;
+}

--- a/scanner/src/index.ts
+++ b/scanner/src/index.ts
@@ -1,12 +1,14 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 import type { ScheduledHandler } from 'aws-lambda';
-import { putDns, type DnsRow } from './dns-repo';
+import { evaluateAndSendAlerts } from './alert';
+import { getDns, putDns, type DnsRow } from './dns-repo';
 import { lookupDns } from './doh';
 import { listVerifiedDomains, type VerifiedDomain } from './domain-list';
 import { lookupWhois } from './rdap';
-import { putSsl, type SslRow } from './ssl-repo';
+import { getSsl, putSsl, type SslRow } from './ssl-repo';
 import { lookupTls } from './tls';
-import { putWhois, type WhoisRow } from './whois-repo';
+import { getUserEmail } from './user-repo';
+import { getWhois, putWhois, type WhoisRow } from './whois-repo';
 
 const CONCURRENCY = 5;
 const logger = new Logger({ serviceName: 'vigil-scanner' });
@@ -24,6 +26,13 @@ export const handler: ScheduledHandler = async (event) => {
 	logger.info('scanning', { count: domains.length });
 
 	const queue = [...domains];
+	const emailCache = new Map<string, string | null>();
+	const getCachedEmail = async (uid: string): Promise<string | null> => {
+		if (emailCache.has(uid)) return emailCache.get(uid) ?? null;
+		const email = await getUserEmail(uid);
+		emailCache.set(uid, email);
+		return email;
+	};
 
 	const worker = async () => {
 		while (queue.length > 0) {
@@ -101,6 +110,31 @@ export const handler: ScheduledHandler = async (event) => {
 					error: msg
 				};
 				await putDns(d.userId, d.hostname, errorRow).catch(() => {});
+			}
+
+			// ALERT (3 scan の結果を読み戻して評価 → SES 送信 or dry-run)
+			try {
+				const email = await getCachedEmail(d.userId);
+				if (!email) {
+					logger.warn('alert_skip_no_email', { uid: d.userId, host: d.hostname });
+				} else {
+					const [w, s, dnsRow] = await Promise.all([
+						getWhois(d.userId, d.hostname),
+						getSsl(d.userId, d.hostname),
+						getDns(d.userId, d.hostname)
+					]);
+					await evaluateAndSendAlerts(
+						{ userId: d.userId, hostname: d.hostname, email },
+						w,
+						s,
+						dnsRow
+					);
+				}
+			} catch (err) {
+				logger.error('alert_failed', {
+					host: d.hostname,
+					err: (err as Error).message ?? 'unknown'
+				});
 			}
 		}
 	};

--- a/scanner/src/user-repo.test.ts
+++ b/scanner/src/user-repo.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { putItem } from './ddb';
+import { getUserEmail } from './user-repo';
+
+const SKIP = !process.env.AWS_ENDPOINT_URL;
+
+describe.skipIf(SKIP)('user-repo (DynamoDB Local)', () => {
+	it('returns email when PROFILE row exists with valid email', async () => {
+		const uid = `user-${Date.now()}`;
+		await putItem({
+			Item: {
+				pk: `USER#${uid}`,
+				sk: 'PROFILE',
+				login: 'octocat',
+				email: 'octo@example.com',
+				created_at: 100
+			}
+		});
+		expect(await getUserEmail(uid)).toBe('octo@example.com');
+	});
+
+	it('returns null when row missing', async () => {
+		expect(await getUserEmail(`absent-${Date.now()}`)).toBeNull();
+	});
+
+	it('returns null when email is missing or invalid', async () => {
+		const uid = `user-noemail-${Date.now()}`;
+		await putItem({
+			Item: {
+				pk: `USER#${uid}`,
+				sk: 'PROFILE',
+				login: 'noemail',
+				created_at: 100
+			}
+		});
+		expect(await getUserEmail(uid)).toBeNull();
+	});
+});

--- a/scanner/src/user-repo.ts
+++ b/scanner/src/user-repo.ts
@@ -1,0 +1,7 @@
+import { getItem } from './ddb';
+
+export async function getUserEmail(userId: string): Promise<string | null> {
+	const r = await getItem({ Key: { pk: `USER#${userId}`, sk: 'PROFILE' } });
+	const email = (r.Item as { email?: string | null } | undefined)?.email;
+	return typeof email === 'string' && email.includes('@') ? email : null;
+}


### PR DESCRIPTION
## Summary

Phase 1 のコア監視ループを完結させる。scan 結果を元に「期限近接 / SSL 切れ / DNS NS 変更」を SES でメール通知する。infra (SES domain identity + DKIM + SPF + DMARC) と app (alert ロジック + handler 統合) の両面を実装。

scope:
- ✅ SES infra (domain identity + Easy DKIM + Route 53 records + verification)
- ✅ scanner alert ロジック (期限判定 30/7/1 日前 + SSL 検証失敗 + NS hash 変更 + dedup + dry-run)
- ✅ handler 統合 (各 worker の 3 scan 後に alert 評価)

scope 外 (別 issue):
- vigil 自身の 5xx 急増 alert → web Lambda 完成後 (#21 以降の別 issue)
- SES bounce/complaint suppression → 本番運用後の別 issue
- \`docs/design/05-alerts.md\` 更新 → #29

## 実装

### scanner (app)
- \`alert.ts\` — kind 判定 (8 種類)、dedup (sub-row \`last_target\` 比較)、dry-run、各 kind の subject/body renderer、SES SendEmail wrapper
- \`alert-repo.ts\` — \`DOMAIN#<host>#ALERT#<KIND>\` sub-row の \`putAlert\` / \`getAlert\`
- \`user-repo.ts\` — \`getUserEmail(userId)\` (USER#<gid>/PROFILE から email 引く)
- \`index.ts\` — worker 末尾に **email cache** + 3 sub-row read + \`evaluateAndSendAlerts\` 呼び出し。alert 失敗は scan 全体を止めない

### infra
- \`ses.tf\` — \`aws_ses_domain_identity\` + \`aws_ses_domain_dkim\` + Route 53 records (DKIM CNAME×3 / SPF / DMARC) + \`aws_ses_domain_identity_verification\` (apply blocking)
- \`iam.tf\` — \`scanner_lambda\` role に \`ses:SendEmail\` policy (\`FromAddress\` condition で sender 限定)
- \`lambda.tf\` — env vars に \`SES_SENDER\` / \`SES_REGION\` / \`SES_DRY_RUN=true\` (初期 dry-run、本番化は #25 で false)
- \`variables.tf\` — \`var.alert_sender\` (default \`notifications@vigil.tommykeyapp.com\`)

### dedup マトリクス

| kind | window | target | 同 target で skip |
|---|---|---|---|
| WHOIS_30D | 7 < days ≤ 30 | \`expires_at\` | 期限変わるまで 1 通 |
| WHOIS_7D | 1 < days ≤ 7 | 同上 | 同上 |
| WHOIS_1D | 0 ≤ days ≤ 1 | 同上 | 同上 |
| SSL_30D/7D/1D | 同様 | \`valid_to\` | cert ローテで再送 |
| SSL_EXPIRED | \`authorized=false\` | \`valid_to\` | cert ローテで再送 |
| DNS_NS_CHANGED | NS hash 差異 | sorted NS join | **初回は baseline 保存のみ** |

## 動作確認 (実施済み)

- [x] \`pnpm -C scanner typecheck\` 0 エラー
- [x] \`pnpm -C scanner test\` **68/68 pass** (新規 21: alert 15 + alert-repo 3 + user-repo 3、既存 47)
  - alert.test.ts: SES vi.mock で network 不使用、kind 境界 / dedup / dry-run / NS_CHANGED baseline / SSL_EXPIRED / email null skip 全網羅
- [x] \`flox activate -- terraform fmt -check && validate\` 通る (既知の hash_key/range_key deprecation 警告のみ)
- [x] DDB Local + 手動 invoke (\`SES_DRY_RUN=true pnpm -C scanner dev\`) で実 scan + alert flow 確認:
  - rdap_ok / tls_ok / dns_ok の 3 scan 全部成功
  - alert_baseline kind=DNS_NS_CHANGED (初回 baseline 保存、send 抑止 = 期待動作)

## 設計判断

- **NS_CHANGED の初回は send 抑止**: scanner 初稼働で全ドメインに baseline を入れるだけで、2 回目以降 hash 差異で発火
- **email cache を worker scope**: 同 user の多ドメインで重複 lookup 回避
- **SES client は lazy init**: vi.mock を class 構文で注入できるよう module-level に new せず getter 経由
- **dry-run 既定**: 初回デプロイは \`SES_DRY_RUN=true\`、sandbox 検証 + 受信 email verify 後に false
- **\`expires_at\` / \`valid_to\` は epoch sec の number** (#15/#16 で確定済) を直接秒数演算

## 残タスク (この PR では対応しない)

- 本番初 apply (SES domain verification + Route 53 反映 + DRY_RUN=false 切替) は **#25**
- 5xx 急増 alert は **#21 後の別 issue**
- bounce/complaint suppression は **本番運用後の別 issue**

## Closes

Closes #19