### PR TITLE
ci: powertools logger + github actions oidc cicd (fixes #22, fixes #23)

### DIFF
--- a/.github/workflows/_deploy-image.yaml
+++ b/.github/workflows/_deploy-image.yaml
@@ -1,0 +1,49 @@
+name: deploy-image (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      directory:
+        description: 'Source directory containing Dockerfile (web | scanner)'
+        required: true
+        type: string
+      function-name:
+        description: 'Lambda function name to update'
+        required: true
+        type: string
+      ecr-repo:
+        description: 'ECR repository name'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: ecr
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.directory }}
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ steps.ecr.outputs.registry }}/${{ inputs.ecr-repo }}:${{ github.sha }}
+            ${{ steps.ecr.outputs.registry }}/${{ inputs.ecr-repo }}:latest
+      - run: |
+          aws lambda update-function-code \
+            --function-name "${{ inputs.function-name }}" \
+            --image-uri "${{ steps.ecr.outputs.registry }}/${{ inputs.ecr-repo }}:${{ github.sha }}" \
+            --output json > /dev/null
+          aws lambda wait function-updated \
+            --function-name "${{ inputs.function-name }}"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,96 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: ap-northeast-1
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.f.outputs.web }}
+      scanner: ${{ steps.f.outputs.scanner }}
+      infra: ${{ steps.f.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: f
+        with:
+          base: main
+          filters: |
+            web:     ['web/**']
+            scanner: ['scanner/**']
+            infra:   ['infra/**', '.github/workflows/**']
+
+  deploy-infra:
+    needs: detect
+    if: needs.detect.outputs.infra == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25 # SES verification 待ちを許容
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.12.2
+      - run: terraform -chdir=infra init
+      - env:
+          TF_VAR_github_oauth_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
+          TF_VAR_github_oauth_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+        run: terraform -chdir=infra apply -auto-approve -input=false
+
+  deploy-scanner:
+    needs: [detect, deploy-infra]
+    if: |
+      always() &&
+      (needs.detect.outputs.scanner == 'true' || github.event_name == 'workflow_dispatch') &&
+      (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
+    uses: ./.github/workflows/_deploy-image.yaml
+    with:
+      directory: scanner
+      function-name: vigil-scanner
+      ecr-repo: vigil-scanner
+    secrets: inherit
+
+  deploy-web:
+    needs: [detect, deploy-infra]
+    if: |
+      always() &&
+      (needs.detect.outputs.web == 'true' || github.event_name == 'workflow_dispatch') &&
+      (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
+    uses: ./.github/workflows/_deploy-image.yaml
+    with:
+      directory: web
+      function-name: vigil-web
+      ecr-repo: vigil-web
+    secrets: inherit
+
+  invalidate-cf:
+    needs: deploy-web
+    if: needs.deploy-web.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+      - id: dist
+        run: |
+          ID=$(aws ssm get-parameter --name /vigil/cloudfront_distribution_id \
+                 --query 'Parameter.Value' --output text)
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+      - run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ steps.dist.outputs.id }}" \
+            --paths '/*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,124 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.f.outputs.web }}
+      scanner: ${{ steps.f.outputs.scanner }}
+      infra: ${{ steps.f.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: f
+        with:
+          base: ${{ github.event.pull_request.base.ref || 'main' }}
+          filters: |
+            web:     ['web/**']
+            scanner: ['scanner/**']
+            infra:   ['infra/**', '.github/workflows/**']
+
+  test-scanner:
+    needs: detect
+    if: needs.detect.outputs.scanner == 'true'
+    runs-on: ubuntu-latest
+    services:
+      dynamodb-local:
+        image: amazon/dynamodb-local:latest
+        ports: ['8000:8000']
+    env:
+      AWS_ENDPOINT_URL: http://127.0.0.1:8000
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: scanner/pnpm-lock.yaml
+      - run: pnpm -C scanner install --frozen-lockfile
+      - run: bash scripts/init-dynamodb-local.sh
+      - run: pnpm -C scanner typecheck
+      - run: pnpm -C scanner test
+
+  test-web:
+    needs: detect
+    if: needs.detect.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    services:
+      dynamodb-local:
+        image: amazon/dynamodb-local:latest
+        ports: ['8000:8000']
+    env:
+      AWS_ENDPOINT_URL: http://127.0.0.1:8000
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+      - run: pnpm -C web install --frozen-lockfile
+      - run: bash scripts/init-dynamodb-local.sh
+      - run: pnpm -C web check
+      - run: pnpm -C web test
+      - run: pnpm -C web build
+
+  tf-plan:
+    needs: detect
+    if: needs.detect.outputs.infra == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PR_ROLE_ARN }}
+          aws-region: ap-northeast-1
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.12.2
+      - run: terraform -chdir=infra fmt -check -diff
+      - run: terraform -chdir=infra init
+      - run: terraform -chdir=infra validate
+      - id: plan
+        run: terraform -chdir=infra plan -no-color -out=tfplan -input=false
+      - name: Comment plan on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('node:child_process');
+            const out = execSync(
+              'terraform -chdir=infra show -no-color tfplan'
+            ).toString();
+            const truncated = out.length > 60000
+              ? out.slice(0, 60000) + '\n... (truncated)'
+              : out;
+            const body = '### Terraform Plan\n```diff\n' + truncated + '\n```';
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/README.md
+++ b/README.md
@@ -96,3 +96,103 @@ pnpm -C scanner typecheck                   # scanner Lambda
 ```
 
 `AWS_ENDPOINT_URL` を外すと DynamoDB Local 依存テストは skip される。
+
+## CI/CD (GitHub Actions OIDC)
+
+本リポは **GitHub Actions OIDC** で AWS にデプロイする (IAM Access Key は使わない)。
+PR 時は `terraform plan` を PR にコメント、main push 時は paths-filter で
+`web` / `scanner` / `infra` に分けて並列デプロイ。
+
+### 初回 bootstrap (1 回だけ手動)
+
+`infra/oidc.tf` で OIDC provider + role を Terraform 管理にしているが、
+Terraform 自身を CI 経由で apply するために卵鶏問題がある。最初の 1 回だけ
+手動で provider と role を作成し、`terraform import` で管理に取り込む。
+
+```sh
+ACCT=$(aws sts get-caller-identity --query Account --output text)
+
+# 1. OIDC provider
+aws iam create-open-id-connect-provider \
+  --url https://token.actions.githubusercontent.com \
+  --client-id-list sts.amazonaws.com
+
+# 2. deploy role (main push 用、PoC で AdministratorAccess 強権限)
+cat > /tmp/trust-deploy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Federated": "arn:aws:iam::${ACCT}:oidc-provider/token.actions.githubusercontent.com"},
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+        "token.actions.githubusercontent.com:sub": "repo:tommykey-apps/vigil:ref:refs/heads/main"
+      }
+    }
+  }]
+}
+EOF
+aws iam create-role --role-name vigil-github-actions-deploy \
+  --assume-role-policy-document file:///tmp/trust-deploy.json
+aws iam put-role-policy --role-name vigil-github-actions-deploy \
+  --policy-name vigil-deploy-admin \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}'
+
+# 3. PR role (read-only + S3 backend RW)
+cat > /tmp/trust-pr.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Federated": "arn:aws:iam::${ACCT}:oidc-provider/token.actions.githubusercontent.com"},
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {"token.actions.githubusercontent.com:aud": "sts.amazonaws.com"},
+      "StringLike":   {"token.actions.githubusercontent.com:sub": "repo:tommykey-apps/vigil:pull_request"}
+    }
+  }]
+}
+EOF
+aws iam create-role --role-name vigil-github-actions-pr \
+  --assume-role-policy-document file:///tmp/trust-pr.json
+aws iam attach-role-policy --role-name vigil-github-actions-pr \
+  --policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess
+aws iam put-role-policy --role-name vigil-github-actions-pr \
+  --policy-name vigil-pr-tfstate \
+  --policy-document "$(cat <<EOF
+{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:PutObject","s3:DeleteObject","s3:ListBucket"],"Resource":["arn:aws:s3:::tommykeyapp-tfstate","arn:aws:s3:::tommykeyapp-tfstate/vigil/*"]}]}
+EOF
+)"
+
+# 4. GitHub Secrets に登録
+gh secret set AWS_DEPLOY_ROLE_ARN -b "arn:aws:iam::${ACCT}:role/vigil-github-actions-deploy"
+gh secret set AWS_PR_ROLE_ARN     -b "arn:aws:iam::${ACCT}:role/vigil-github-actions-pr"
+# prod GitHub OAuth App は #25 で作成、その時点で値が決まる
+gh secret set GH_OAUTH_CLIENT_ID     -b "(prod OAuth App ID、#25 で設定)"
+gh secret set GH_OAUTH_CLIENT_SECRET -b "(prod OAuth App secret、#25 で設定)"
+```
+
+### PR-A merge 後に Terraform 管理へ移行
+
+`oidc.tf` が apply されると既存リソースと衝突するので、merge 直後に手動で import:
+
+```sh
+cd infra
+ACCT=$(aws sts get-caller-identity --query Account --output text)
+flox activate -- terraform import aws_iam_openid_connect_provider.github \
+  arn:aws:iam::${ACCT}:oidc-provider/token.actions.githubusercontent.com
+flox activate -- terraform import aws_iam_role.github_actions_deploy vigil-github-actions-deploy
+flox activate -- terraform import aws_iam_role.github_actions_pr     vigil-github-actions-pr
+flox activate -- terraform plan   # diff が小さいことを確認 (assume_role_policy / attached policies 等)
+flox activate -- terraform apply  # 残り attached policy 等を反映
+```
+
+### Workflows 構成
+
+| File | Trigger | Jobs |
+|---|---|---|
+| `.github/workflows/ci.yaml` | PR / merge_group | `detect` → `test-scanner` / `test-web` / `tf-plan` (paths-filter で条件分岐) |
+| `.github/workflows/cd.yaml` | main push / `workflow_dispatch` | `detect` → `deploy-infra` → `deploy-scanner` / `deploy-web` (reusable) → `invalidate-cf` |
+| `.github/workflows/_deploy-image.yaml` | `workflow_call` | image build → ECR push → `lambda update-function-code` → `lambda wait function-updated` |

--- a/infra/oidc.tf
+++ b/infra/oidc.tf
@@ -1,0 +1,110 @@
+# GitHub Actions OIDC provider と deploy / pr role 定義。
+# 初回 apply 時の卵鶏問題を避けるため、これらは tommykey が手動で先に
+# bootstrap して `terraform import` する想定 (README に手順あり)。
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+  tags = {
+    Project = var.project
+  }
+}
+
+# main push 時の deploy 用 (強権限、PoC)
+resource "aws_iam_role" "github_actions_deploy" {
+  name = "${var.project}-github-actions-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = aws_iam_openid_connect_provider.github.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:sub" = "repo:tommykey-apps/vigil:ref:refs/heads/main"
+        }
+      }
+    }]
+  })
+
+  tags = {
+    Project = var.project
+  }
+}
+
+# PoC 強権限。本番安定後に最小権限へ絞る (別 issue)
+resource "aws_iam_role_policy" "github_actions_deploy_admin" {
+  name = "${var.project}-deploy-admin"
+  role = aws_iam_role.github_actions_deploy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "*"
+      Resource = "*"
+    }]
+  })
+}
+
+# PR 時の read-only 用 (terraform plan)
+resource "aws_iam_role" "github_actions_pr" {
+  name = "${var.project}-github-actions-pr"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = aws_iam_openid_connect_provider.github.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:tommykey-apps/vigil:pull_request"
+        }
+      }
+    }]
+  })
+
+  tags = {
+    Project = var.project
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_pr_readonly" {
+  role       = aws_iam_role.github_actions_pr.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# PR plan で S3 backend に write が必要 (lockfile 取得 + state read)。
+# ReadOnlyAccess は state read は OK だが、S3 lockfile object の put が
+# できないので、追加で S3 backend bucket への RW を付与
+resource "aws_iam_role_policy" "github_actions_pr_tfstate" {
+  name = "${var.project}-pr-tfstate"
+  role = aws_iam_role.github_actions_pr.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ]
+      Resource = [
+        "arn:aws:s3:::tommykeyapp-tfstate",
+        "arn:aws:s3:::tommykeyapp-tfstate/vigil/*"
+      ]
+    }]
+  })
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -37,3 +37,13 @@ output "scanner_dlq_arn" {
   description = "SQS DLQ ARN for scanner schedule failures"
   value       = aws_sqs_queue.scanner_dlq.arn
 }
+
+output "github_actions_deploy_role_arn" {
+  description = "IAM role ARN for GitHub Actions main-push deploy (configure-aws-credentials)"
+  value       = aws_iam_role.github_actions_deploy.arn
+}
+
+output "github_actions_pr_role_arn" {
+  description = "IAM role ARN for GitHub Actions PR-time terraform plan (read-only)"
+  value       = aws_iam_role.github_actions_pr.arn
+}

--- a/scanner/package.json
+++ b/scanner/package.json
@@ -13,7 +13,8 @@
     "@aws-lambda-powertools/logger": "^2.20.0",
     "@aws-sdk/client-dynamodb": "^3.700.0",
     "@aws-sdk/client-ses": "^3.700.0",
-    "@aws-sdk/lib-dynamodb": "^3.700.0"
+    "@aws-sdk/lib-dynamodb": "^3.700.0",
+    "@middy/core": "^7.3.3"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.150",

--- a/scanner/pnpm-lock.yaml
+++ b/scanner/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@aws-lambda-powertools/logger':
         specifier: ^2.20.0
-        version: 2.33.0
+        version: 2.33.0(@middy/core@7.3.3)
       '@aws-sdk/client-dynamodb':
         specifier: ^3.700.0
         version: 3.1037.0
@@ -20,6 +20,9 @@ importers:
       '@aws-sdk/lib-dynamodb':
         specifier: ^3.700.0
         version: 3.1037.0(@aws-sdk/client-dynamodb@3.1037.0)
+      '@middy/core':
+        specifier: ^7.3.3
+        version: 7.3.3
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.150
@@ -373,6 +376,19 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@middy/core@7.3.3':
+    resolution: {integrity: sha512-Wy6zjpaMo3yiU3+GR2d8HQhx7jnuDkPL5O2vSzLgw2OJmTkrMRREz8MMVUq24XrWyR1OX+xGRqSJJwC7NJP60A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@aws/durable-execution-sdk-js': ^1.0.0
+    peerDependenciesMeta:
+      '@aws/durable-execution-sdk-js':
+        optional: true
+
+  '@middy/util@7.3.3':
+    resolution: {integrity: sha512-BR6zrbF3utbVobZfFa1eEbOu7u51uzrtQVJCAS3So/5dzlPF/8Q9Ediwu4lV8y1gLGzWAuhbZZL8JBWX6O4Bcg==}
+    engines: {node: '>=22'}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1048,10 +1064,12 @@ snapshots:
     dependencies:
       '@aws/lambda-invoke-store': 0.2.4
 
-  '@aws-lambda-powertools/logger@2.33.0':
+  '@aws-lambda-powertools/logger@2.33.0(@middy/core@7.3.3)':
     dependencies:
       '@aws-lambda-powertools/commons': 2.33.0
       '@aws/lambda-invoke-store': 0.2.4
+    optionalDependencies:
+      '@middy/core': 7.3.3
 
   '@aws-sdk/client-dynamodb@3.1037.0':
     dependencies:
@@ -1565,6 +1583,12 @@ snapshots:
     optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@middy/core@7.3.3':
+    dependencies:
+      '@middy/util': 7.3.3
+
+  '@middy/util@7.3.3': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:

--- a/scanner/src/index.ts
+++ b/scanner/src/index.ts
@@ -1,4 +1,6 @@
 import { Logger } from '@aws-lambda-powertools/logger';
+import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware';
+import middy from '@middy/core';
 import type { ScheduledHandler } from 'aws-lambda';
 import { evaluateAndSendAlerts } from './alert';
 import { getDns, putDns, type DnsRow } from './dns-repo';
@@ -13,7 +15,7 @@ import { getWhois, putWhois, type WhoisRow } from './whois-repo';
 const CONCURRENCY = 5;
 const logger = new Logger({ serviceName: 'vigil-scanner' });
 
-export const handler: ScheduledHandler = async (event) => {
+const baseHandler: ScheduledHandler = async (event) => {
 	logger.info('scanner invoked', { event });
 
 	let domains: VerifiedDomain[];
@@ -143,7 +145,13 @@ export const handler: ScheduledHandler = async (event) => {
 	logger.info('scan_complete');
 };
 
+// Powertools Logger を middy で wrap (cold_start + requestId 自動付与、
+// clearState=true で前回 invocation の persistent keys 残留を防止)
+export const handler = middy(baseHandler).use(
+	injectLambdaContext(logger, { logEvent: false, clearState: true })
+);
+
 // ローカル手動 invoke (`pnpm -C scanner dev`)
 if (import.meta.url === `file://${process.argv[1]}`) {
-	void handler({} as never, {} as never, () => {});
+	void handler({} as never, {} as never);
 }


### PR DESCRIPTION
## Summary

PR-A of the production rollout set (4 PR plan in \`/home/tommykey0925/.claude/plans/curious-noodling-peach.md\`). Issues #22 (Powertools Logger) と #23 (GitHub Actions OIDC + paths-filter CI/CD) を 1 PR にまとめた。

**Draft 状態** にしているのは、CI が動くには **OIDC bootstrap (tommykey 手動作業)** が先に必要なため。bootstrap 完了 + GitHub Secrets 登録後に Ready for review に上げる。

## 実装

### scanner (Powertools Logger 統合)
- \`@aws-lambda-powertools/logger\` ^2.x + \`@middy/core\` ^7.x を追加
- \`scanner/src/index.ts\` で \`injectLambdaContext\` を middy で wrap、\`clearState: true\` で前回 invocation の persistent keys 残留を防止
- 既存 Logger usage そのまま、cold_start / requestId / functionName が自動付与される構造化 JSON 出力に

### GitHub Actions Workflows (3 本)
- \`ci.yaml\` — PR/merge_group: paths-filter (web/scanner/infra) + test-scanner / test-web (DynamoDB Local services) + tf-plan (OIDC role assume → \`terraform plan\` PR コメント)
- \`cd.yaml\` — main push/workflow_dispatch: detect → deploy-infra (terraform apply、SES verification 待ち timeout 25min) → reusable image deploy → CloudFront invalidation
- \`_deploy-image.yaml\` — \`workflow_call\` で web/scanner 共通 (docker buildx + ECR push + lambda update + wait)

### Terraform IAM
- \`infra/oidc.tf\` (新規) — \`aws_iam_openid_connect_provider\` + deploy role (main 限定 sub) + PR role (read-only + S3 backend RW for tfstate)
- \`infra/outputs.tf\` — deploy/PR role ARN を export

### README
- CI/CD bootstrap 手順 (1 回だけ手動): OIDC provider + 仮 role 作成 → GitHub Secrets 登録 → PR-A merge 後 \`terraform import\` で管理移行
- Workflows 構成 (file/trigger/jobs)

## 動作確認 (実施済み)

- [x] \`pnpm -C scanner typecheck\` 0 エラー
- [x] \`pnpm -C scanner test\` **68/68 pass** (Logger 差し替え後も既存テスト保持)
- [x] \`flox activate -- terraform -chdir=infra fmt -check && validate\` 通る (既知の hash_key deprecation 警告のみ)
- [x] Python yaml で workflows YAML 構文 OK

## Pre-merge checklist (tommykey に依頼)

PR を Ready for review する前に以下の bootstrap が必要 (詳細は README 参照):

1. \`aws iam create-open-id-connect-provider\` で OIDC provider 作成
2. \`vigil-github-actions-deploy\` role を AdministratorAccess で仮作成 (PoC)
3. \`vigil-github-actions-pr\` role を ReadOnlyAccess + tfstate RW で仮作成
4. \`gh secret set\` で \`AWS_DEPLOY_ROLE_ARN\` / \`AWS_PR_ROLE_ARN\` 登録
5. \`GH_OAUTH_CLIENT_ID\` / \`_SECRET\` は #25 (PR-D) で確定するので一旦 dummy か未設定

## Post-merge tasks

- \`terraform import\` で OIDC リソースを管理移行 (README に手順)
- 続く PR-B (#24 Rulesets) は本 PR の CI job 名 (\`test-scanner\` / \`test-web\` / \`tf-plan\`) を \`required_status_checks.context\` に使う

## Closes

Closes #22
Closes #23