### PR TITLE
fix(ci): force docker manifest for lambda + disable deploy-web

### DIFF
--- a/.github/workflows/_deploy-image.yaml
+++ b/.github/workflows/_deploy-image.yaml
@@ -37,6 +37,10 @@ jobs:
           context: ${{ inputs.directory }}
           platforms: linux/arm64
           push: true
+          # AWS Lambda は OCI manifest list を受け付けないため Docker manifest に固定
+          # (buildx の default `provenance: max` だと manifest index が作られる)
+          provenance: false
+          sbom: false
           tags: |
             ${{ steps.ecr.outputs.registry }}/${{ inputs.ecr-repo }}:${{ github.sha }}
             ${{ steps.ecr.outputs.registry }}/${{ inputs.ecr-repo }}:latest

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -64,11 +64,11 @@ jobs:
     secrets: inherit
 
   deploy-web:
+    # TODO(#21): web Lambda + ECR repo を Terraform で定義するまで disable。
+    # PR-C で web Lambda が provision されたら if 条件を deploy-scanner と
+    # 同形に戻す。
+    if: false
     needs: [detect, deploy-infra]
-    if: |
-      always() &&
-      (needs.detect.outputs.web == 'true' || github.event_name == 'workflow_dispatch') &&
-      (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
     uses: ./.github/workflows/_deploy-image.yaml
     with:
       directory: web


### PR DESCRIPTION
## Summary

PR #45 (PR-A) merge 後の CD で deploy-scanner が \`InvalidParameterValueException\` で fail。原因と修正:

### 1. AWS Lambda が OCI manifest list を受け付けない

\`docker/build-push-action@v6\` の default は \`provenance: max\` で、buildx が **OCI manifest index** (multi-arch index 形式) を push する。AWS Lambda はこれを reject:

\`\`\`
The image manifest, config or layer media type for the source image
... is not supported.
\`\`\`

**修正**: \`_deploy-image.yaml\` に \`provenance: false\` + \`sbom: false\` を追加して single-platform Docker manifest に強制。

### 2. deploy-web を一時 skip

web Lambda + ECR repo \`vigil-web\` はまだ Terraform で定義されていない (PR-C / #21 で実装予定) ため、deploy-web は毎回 docker push で fail。

**修正**: \`cd.yaml\` の deploy-web を \`if: false\` で skip。PR-C で web 側 infra ができたら通常の if 条件に戻す。

## 動作確認 (実施済み)

- [x] YAML 構文 OK (Python yaml で validate)
- [x] CD 直前の状態: deploy-infra 成功、scanner image build/push 成功、lambda update のみ fail (image format 起因) → PR merge 後の CD で解消する想定

## 影響範囲

- 本 PR は CI/CD のみ。アプリコード / Terraform / scanner には変更なし
- merge → CD 自動実行 → deploy-scanner が成功するはず