### PR TITLE
fix(scanner): copy package.json to lambda task root

### DIFF
--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -8,6 +8,9 @@ RUN pnpm build && pnpm prune --prod
 
 FROM --platform=linux/arm64 public.ecr.aws/lambda/nodejs:24-arm64
 WORKDIR ${LAMBDA_TASK_ROOT}
+# package.json も同梱しないと Node が "type": "module" を解決できず、
+# import 文が SyntaxError になる
+COPY --from=builder /app/package.json ./
 COPY --from=builder /app/dist ./
 COPY --from=builder /app/node_modules ./node_modules
 CMD ["index.handler"]


### PR DESCRIPTION
Lambda が dist/index.js を CommonJS として実行してしまい SyntaxError。package.json を Lambda task root に COPY して `"type": "module"` を解決できるようにする。